### PR TITLE
Remove reference to seed-ci role from bastion conf

### DIFF
--- a/bastion.yml
+++ b/bastion.yml
@@ -4,7 +4,6 @@
   roles:
     - common
     - bastion
-    - seed-ci
     - role: cron-ansible
       ansible_root: /opt/source/hoist
       ansible_playbook: bastion.yml


### PR DESCRIPTION
PR #4  looks to have moved the important parts of seed-ci's role into
cron-ansible, but bastion.yml is still attemting to use the removed
seed-ci role. Removed reference to deleted role.