### PR TITLE
Fix virtualenv package name

### DIFF
--- a/roles/ansible/tasks/main.yml
+++ b/roles/ansible/tasks/main.yml
@@ -5,7 +5,7 @@
   with_items:
     - python-dev
     - libssl-dev
-    - virtualenv
+    - python-virtualenv
 
 - name: Install ansible
   pip:


### PR DESCRIPTION
On ubuntu the virtualenv package in apt is named python-virtualenv not
virtualenv.