### PR TITLE
Fix bugs in first run of bastion.

### DIFF
--- a/bastion.yml
+++ b/bastion.yml
@@ -8,7 +8,7 @@
     - role: cron-ansible
       ansible_root: /opt/source/hoist
       ansible_playbook: bastion.yml
-      ansible_inventory: /etc/ansible/hosts
+      ansible_inventory: /opt/source/hoist/inventory/bastion-localhost
       ansible_runner_user: root
     - role: cron-cideploy
       ansible_playbook: install-ci.yml

--- a/inventory/bastion-localhost
+++ b/inventory/bastion-localhost
@@ -1,0 +1,2 @@
+[bastion]
+localhost ansible_connection=local

--- a/roles/bastion/tasks/main.yml
+++ b/roles/bastion/tasks/main.yml
@@ -33,6 +33,14 @@
     state: absent
   notify: restart sshd
 
+- name: install required ubuntu packages
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - libssl-dev
+    - python-dev
+
 - name: install required python packages
   pip:
     name: "{{ item }}"

--- a/roles/bastion/tasks/main.yml
+++ b/roles/bastion/tasks/main.yml
@@ -33,16 +33,6 @@
     state: absent
   notify: restart sshd
 
-- name: Self reference in default ansible inventory
-  copy:
-    content: |
-      [bastion]
-      localhost ansible_connection=local
-    dest: /etc/ansible/hosts
-    owner: root
-    group: root
-    mode: 0600
-
 - name: install required python packages
   pip:
     name: "{{ item }}"


### PR DESCRIPTION
Fixup bugs in running bastion for the first time. 

The /etc/ansible/ directory doesn't exist to write an inventory too and the shade package can't be installed without some additional ubuntu packages.