### PR TITLE
Remove removal log creation

### DIFF
--- a/roles/ansible-runner/files/usr/local/bin/ansible-runner
+++ b/roles/ansible-runner/files/usr/local/bin/ansible-runner
@@ -36,5 +36,4 @@ ansible-playbook -i $ANSIBLE_INVENTORY $args $ANSIBLE_PLAYBOOK 2>&1 | tee -a $lo
 date 2>&1 | tee -a $logfile
 
 # Remove > 10 days old
-RMLOG=/var/www/html/cron-logs/$env/removal_${timestamp}.log
-find /var/www/html/cron-logs/$env -type f -name '*.log' -mtime 10 -exec rm -f {} \; > $RMLOG 2>&1
+find /var/www/html/cron-logs/$env -type f -name '*.log' -mtime 10 -exec rm -f {} \;


### PR DESCRIPTION
Creating a log file for removed logs is not really useful. Until it
actually starts deleting things it's creating lots of empty files, and
later all it will tell us is files that we can no longer actually get
to. Let's just not log these.