### PR TITLE
Create our own pip role.

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,3 @@
-- src: mbasanta.pip
-  name: pip
-
 - src: https://git.openstack.org/openstack/ansible-role-nodepool
   scm: git
   version: master

--- a/roles/pip/README.md
+++ b/roles/pip/README.md
@@ -1,0 +1,26 @@
+Pip
+===
+
+Install the latest version of pip.
+
+Role Variables
+--------------
+
+Defaults:
+
+- `pip_cache_dir`: The directory that the `get-pip.py` bootstrapper will be downloaded to. Defaults to `/var/cache/pip-installer`.
+- `pip_install_url`: The url to download the `get-pip.py` bootstrapper. Defaults to `https://bootstrap.pypa.io/get-pip.py`.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - role: pip
+
+License
+-------
+
+Apache 2

--- a/roles/pip/defaults/main.yml
+++ b/roles/pip/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+pip_cache_dir: /var/cache/pip-installer
+pip_install_url: https://bootstrap.pypa.io/get-pip.py

--- a/roles/pip/meta/main.yml
+++ b/roles/pip/meta/main.yml
@@ -1,0 +1,12 @@
+galaxy_info:
+  author: Jamie Lennox
+  description: Install pip from pypa.
+  company: IBM
+
+  license: Apache
+
+  # this is all we're using at the moment.
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all

--- a/roles/pip/tasks/main.yml
+++ b/roles/pip/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: Create cache dir for pip downloads
+  file:
+    path: "{{ pip_cache_dir }}"
+    mode: 0755
+    state: directory
+
+- name: Download the Pip installer to /tmp
+  get_url:
+    url: "{{ pip_install_url }}"
+    dest: "{{ pip_cache_dir }}/get-pip.py"
+
+- name: Run get-pip.py to intall Pip
+  command: "python {{ pip_cache_dir }}/get-pip.py"
+  register: pip_command
+  changed_when: "'Requirement already up-to-date: pip' not in pip_command.stdout"


### PR DESCRIPTION
The upstream role is basically unmanaged. I'm not a fan of using these
galaxy roles because they are small, unmanaged and often do things
different to what we need. Let's maintain our own of these.