### PR TITLE
Fix path to bastion-localhost inventory

### DIFF
--- a/bastion.yml
+++ b/bastion.yml
@@ -9,7 +9,7 @@
     - role: ansible-runner
       ansible_runner_job: system-ansible
       ansible_playbook: bastion.yml
-      ansible_inventory: /opt/source/hoist/inventory/bastion-localhost
+      ansible_inventory: /opt/source/system-ansible/inventory/bastion-localhost
       ansible_runner_user: root
       ansible_runner_repo: https://github.com/BonnyCI/hoist.git
       ansible_runner_minute: "*/15"


### PR DESCRIPTION
This file is checked out to a repo based on job name, not based on the
repo name.