### PR TITLE
Introduce monitoring for mysql process

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -13,6 +13,9 @@
   tags: ['mysql']
   roles:
     - role: mysql
+    - role: dd-mysql
+      tags:
+        - monitoring
     - role: databases
 
 - name: Install zuul

--- a/roles/dd-agent/defaults/main.yml
+++ b/roles/dd-agent/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+dd_agent:
+  frags:
+    - process

--- a/roles/dd-agent/files/etc/dd-agent/frags/process/0process
+++ b/roles/dd-agent/files/etc/dd-agent/frags/process/0process
@@ -1,0 +1,3 @@
+init_config:
+
+instances:

--- a/roles/dd-agent/tasks/main.yml
+++ b/roles/dd-agent/tasks/main.yml
@@ -27,6 +27,14 @@
   notify:
     - restart dd-agent
 
+# This is required to call datadog_monitor with ansible and later to use the
+# datadog callback for more integration into ansible runs
+# within datadog.
+- name: install datadog pip
+  pip:
+    name: datadog
+    virtualenv: /opt/datadog
+
 - name: configure datadog
   template:
     src: etc/dd-agent/datadog.conf
@@ -35,6 +43,24 @@
     group: root
   notify:
     - restart dd-agent
+
+- name: create fragments dir for assembling config
+  file:
+    path: "/etc/dd-agent/frags/{{ item }}"
+    state: directory
+    owner: dd-agent
+    group: root
+  with_items: "{{ dd_agent.frags }}"
+
+- name: drop base fragments
+  copy:
+    dest: /etc/dd-agent/frags/{{ item }}/0{{ item }}
+    src: etc/dd-agent/frags/{{ item }}/0{{ item }}
+    owner: dd-agent
+    group: root
+  with_items: "{{ dd_agent.frags }}"
+  notify:
+    - assemble dd-agent config frags
 
 # Flush handlers to avoid a start + restart scenario
 - meta: flush_handlers

--- a/roles/dd-common/handlers/main.yml
+++ b/roles/dd-common/handlers/main.yml
@@ -1,4 +1,14 @@
 ---
+# Assemble fragments and restart
+- name: assemble dd-agent config frags
+  assemble:
+    dest: "/etc/dd-agent/conf.d/{{ item }}.yaml"
+    src: "/etc/dd-agent/frags/{{ item }}"
+    remote_src: yes
+  with_items: "{{ dd_agent.frags }}"
+  notify:
+    - restart dd-agent
+
 - name: restart dd-agent
   service:
     name: datadog-agent

--- a/roles/dd-mysql/files/etc/dd-agent/frags/process/mysql
+++ b/roles/dd-mysql/files/etc/dd-agent/frags/process/mysql
@@ -1,0 +1,2 @@
+  - name: mysql
+    search_string: ['mysqld']

--- a/roles/dd-mysql/meta/main.yml
+++ b/roles/dd-mysql/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: dd-common

--- a/roles/dd-mysql/tasks/main.yml
+++ b/roles/dd-mysql/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Check mysqld process
+  copy:
+    src: etc/dd-agent/frags/process/mysql
+    dest: /etc/dd-agent/frags/process/mysql
+  notify:
+    - assemble dd-agent config frags
+
+- name: create monitor for mysqld process check
+  datadog_monitor:
+    api_key: "{{ secrets.datadog.api_key }}"
+    app_key: "{{ secrets.datadog.ansible_app_key }}"
+    name: mysqld process from ansible
+    state: present
+    type: "service check"
+    message: "mysql is down"
+    query: '"process.up".over("host:{{ ansible_hostname }}","process:mysql").last(3).count_by_status()'
+  vars:
+    ansible_python_interpreter: /opt/datadog/bin/python

--- a/secrets.yml.example
+++ b/secrets.yml.example
@@ -17,3 +17,4 @@ secrets:
           region_name: RegionOne
   datadog:
     api_key: demokeyhash
+    ansible_app_key: demoapphash


### PR DESCRIPTION
There is a lot of change here:
- Create a method in dd-agent to write out fragments for checks that
  require all configuration in them to be in a single file
- Establish a pattern of putting monitoring bits for each role in a
  specific file that can be included/tagged
- Create a process check for the mysqld process
- Create a monitor for the mysqld process check