### PR TITLE
Add datadog ansible callback

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,4 @@
 [defaults]
 roles_path = upstream_roles:roles
+# Change this path of ansible_runner_virtualenv ever changes
+callback_plugins = /opt/ansible/plugins/callback

--- a/roles/ansible-runner/defaults/main.yml
+++ b/roles/ansible-runner/defaults/main.yml
@@ -1,3 +1,4 @@
 ansible_runner_user: root
 ansible_runner_secrets_path: /etc/secrets.yml
 ansible_runner_virtualenv: /opt/ansible
+datadog_callback_url: https://raw.githubusercontent.com/DataDog/ansible-datadog-callback/master/datadog_callback.py

--- a/roles/ansible-runner/tasks/main.yml
+++ b/roles/ansible-runner/tasks/main.yml
@@ -13,6 +13,28 @@
     virtualenv: "{{ ansible_runner_virtualenv }}"
     name: ansible
 
+- name: Create callback plugins path
+  file:
+    path: "{{ ansible_runner_virtualenv }}/plugins/callback"
+    state: directory
+    owner: "{{ ansible_runner_user }}"
+
+- block:
+  - name: Install datadog callback plugin
+    get_url:
+      url: "{{ datadog_callback_url }}"
+      dest: "{{ ansible_runner_virtualenv }}/plugins/callback/datadog_callback.py"
+      owner: "{{ ansible_runner_user }}"
+
+  - name: Install datadog callback configuration
+    copy:
+      dest: "{{ ansible_runner_virtualenv }}/plugins/callback/datadog_callback.yml"
+      content: "api_key: {{ secrets.datadog.api_key }}"
+      owner: "{{ ansible_runner_user }}"
+  when: datadog_enabled | default(True) | bool
+  tags:
+    - datadog
+
 - name: Install config file
   template:
     src: ansible-runner-config


### PR DESCRIPTION
The callback plugin plus configuration go into ansible's virtualenv
path. The in-repo ansible.cfg is set to use that path, and if the path
doesn't exist, no error is thrown, so it's safe to run outside of our
bastion (however one can opt-in to having it send data from our personal
runs).

Fixes #32