### PR TITLE
Install python requirments for our hoist repo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+datadog

--- a/roles/ansible-runner/files/usr/local/bin/ansible-runner
+++ b/roles/ansible-runner/files/usr/local/bin/ansible-runner
@@ -22,6 +22,7 @@ logfile="/var/www/html/cron-logs/$env/ansible_${playbook}_current.log"
 dst_logfile="/var/www/html/cron-logs/$env/ansible_${playbook}_${timestamp}.log"
 
 cd /opt/source/$env
+pip install -U -r requirements.txt
 trap "cp $logfile $dst_logfile; rm -f /var/www/html/cron-logs/$env/ansible_${playbook}_latest.log; ln -s $dst_logfile /var/www/html/cron-logs/$env/ansible_${playbook}_latest.log" EXIT
 
 date 2>&1 | tee $logfile


### PR DESCRIPTION
Our deploy tooling has some python deps. Lets use requirements.txt and
have our runner script apply our repo requirements before running.