### PR TITLE
Use gearman server instead of zuul launched gearman

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -23,7 +23,10 @@
   become: yes
   tags: ['zuul']
   roles:
+    - role: gearman
+    - role: dd-gearman
     - role: zuul
+      zuul_gearman_server_start: false
 
 - name: Install nodepool
   hosts: nodepool.portbleu.com

--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -2,3 +2,10 @@ zuul_git_repo_url: https://git.openstack.org/openstack-infra/zuul
 zuul_git_branch: master
 zuul_venv_dir: /opt/venvs/zuul
 zuul_allow_restart_services: no
+
+zuul_gearman_server: 127.0.0.1
+zuul_gearman_port: 4730
+
+zuul_gearman_server_start: true
+zuul_gearman_server_log_config: /etc/zuul/gearman-logging.conf
+zuul_gearman_server_listen_address: 127.0.0.1

--- a/roles/zuul/templates/etc/zuul/zuul.conf
+++ b/roles/zuul/templates/etc/zuul/zuul.conf
@@ -1,13 +1,13 @@
 # {{ ansible_managed }}
 
 [gearman]
-port = 4730
-server = 127.0.0.1
+port = {{ zuul_gearman_port }}
+server = {{ zuul_gearman_server }}
 
 [gearman_server]
-listen_address = 127.0.0.1
-log_config = /etc/zuul/gearman-logging.conf
-start = true
+listen_address = {{ zuul_gearman_server_listen_address }}
+log_config = {{ zuul_gearman_server_log_config }}
+start = {{ zuul_gearman_server_start }}
 
 [gerrit]
 port = 29418


### PR DESCRIPTION
We can monitor a long running gearman process rather than have this be
something the zuul server is responsible for.