### PR TITLE
Publicly log from the nodepool node

### DIFF
--- a/roles/nodepool/meta/main.yml
+++ b/roles/nodepool/meta/main.yml
@@ -1,1 +1,7 @@
 ---
+dependencies:
+  - role: apache
+    apache_vhosts:
+      - name: nodepool
+        document_root: /var/log/nodepool/
+        document_root_options: +FollowSymLinks


### PR DESCRIPTION
In order to enable debugging set up apache and expose nodepool logs over
it.