### PR TITLE
Tag dd-* tasks as monitoring

### DIFF
--- a/bastion.yml
+++ b/bastion.yml
@@ -4,6 +4,8 @@
   roles:
     - common
     - role: dd-agent
+      tags:
+        - monitoring
       when: secrets is defined
     - bastion
     - role: ansible-runner

--- a/install-ci.yml
+++ b/install-ci.yml
@@ -6,6 +6,8 @@
   roles:
     - role: common
     - role: dd-agent
+      tags:
+        - monitoring
 
 - name: Install mysql
   hosts: zuul.portbleu.com
@@ -25,9 +27,13 @@
   roles:
     - role: gearman
     - role: dd-gearman
+      tags:
+        - monitoring
     - role: zuul
       zuul_gearman_server_start: false
     - role: dd-zuul
+      tags:
+        - monitoring
 
 - name: Install nodepool
   hosts: nodepool.portbleu.com


### PR DESCRIPTION
To speed up local development, I prefer to skip all of the monitoring
tasks, especially when running 'common'.  This tags them as monitoring
so they may be run or skipped at will.