### PR TITLE
Add support for getting secrets from a vault

### DIFF
--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -1,1 +1,2 @@
 nodepool_mysql_host: 192.168.3.164
+ansible_runner_vault_password_file: /etc/vault_pass.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
+# for datadog callback
 datadog
+# for ansible vault
+cryptography

--- a/roles/ansible-runner/templates/ansible-runner-config
+++ b/roles/ansible-runner/templates/ansible-runner-config
@@ -1,3 +1,6 @@
 ANSIBLE_PLAYBOOK={{ ansible_playbook }}
 ANSIBLE_INVENTORY={{ ansible_inventory }}
 ANSIBLE_SSH_USER={{ ansible_remote_user | default('') }}
+{% if ansible_runner_vault_password_file is defined %}
+ANSIBLE_VAULT_PASSWORD_FILE={{ ansible_runner_vault_password_file }}
+{% endif %}


### PR DESCRIPTION
This introduces the tooling to be able to use a vault encrypted file for
our secrets. A vault password file is defined in inventory, and will
have to be manually created on the runner host. The path to this file is
exposed as a ENV variable and is read by ansible(-playbook) at execution
time (rather than passed in as an explicit runtime option). For that
reason if a path is not defined in inventory variables, the ENV entry is
not created.

Related to #18