### PR TITLE
Manage clouds.yamls via secrets.yml

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -35,3 +35,5 @@
   tags: ['nodepool']
   roles:
     - role: nodepool
+      nodepool_providers:
+        - nodepool-provider1

--- a/roles/bastion/meta/main.yml
+++ b/roles/bastion/meta/main.yml
@@ -1,0 +1,6 @@
+dependencies:
+  - role: os-clouds
+    clouds_yaml_group: cideploy
+    clouds_yaml_mode: 0640
+    clouds:
+      - contra-sjc

--- a/roles/nodepool/defaults/main.yml
+++ b/roles/nodepool/defaults/main.yml
@@ -1,3 +1,4 @@
 nodepool_source_dir: /opt/source/nodepool
 nodepool_venv_dir: /opt/venvs/nodepool
 nodepool_mysql_host: localhost
+nodepool_providers: []

--- a/roles/nodepool/meta/main.yml
+++ b/roles/nodepool/meta/main.yml
@@ -5,3 +5,7 @@ dependencies:
       - name: nodepool
         document_root: /var/log/nodepool/
         document_root_options: +FollowSymLinks
+  - role: os-clouds
+    clouds_yaml_owner: nodepool
+    clouds_yaml_path: /var/lib/nodepool/.config/openstack/clouds.yaml
+    clouds: "{{ nodepool_providers }}"

--- a/roles/nodepool/tasks/main.yml
+++ b/roles/nodepool/tasks/main.yml
@@ -36,21 +36,6 @@
     owner: nodepool
     group: nodepool
 
-- name: create ~/.openstack
-  file:
-    path: /var/lib/nodepool/.config/openstack
-    state: directory
-    owner: nodepool
-    group: nodepool
-
-- name: create clouds.yaml
-  copy:
-    dest: /var/lib/nodepool/.config/openstack/clouds.yaml
-    content: "{{ secrets.nodepool.providers | to_nice_yaml }}"
-    owner: nodepool
-    group: nodepool
-    mode: 0400
-
 - name: Git clone nodepool
   git:
     dest: "{{ nodepool_source_dir }}"

--- a/roles/os-clouds/defaults/main.yml
+++ b/roles/os-clouds/defaults/main.yml
@@ -1,0 +1,5 @@
+clouds_yaml_path: /etc/openstack/clouds.yaml
+clouds_yaml_owner: root
+clouds_yaml_group: "{{ clouds_yaml_owner }}"
+clouds_yaml_mode: 0400
+clouds: []

--- a/roles/os-clouds/tasks/main.yml
+++ b/roles/os-clouds/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: Ensure clouds.yaml group exists
+  group:
+    name: "{{ clouds_yaml_group }}"
+    state: present
+
+- name: Ensure clouds.yaml owner exists
+  user:
+    name: "{{ clouds_yaml_owner }}"
+    group: "{{ clouds_yaml_group }}"
+    state: present
+
+- name: Ensure clouds.yaml directory
+  file:
+    path: "{{ clouds_yaml_path | dirname }}"
+    state: directory
+    owner: "{{ clouds_yaml_owner }}"
+
+- name: Write clouds.yaml
+  template:
+    src: clouds.yaml
+    dest:  "{{ clouds_yaml_path }}"
+    owner: "{{ clouds_yaml_owner }}"
+    group: "{{ clouds_yaml_group }}"
+    mode: "{{ clouds_yaml_mode }}"

--- a/roles/os-clouds/templates/clouds.yaml
+++ b/roles/os-clouds/templates/clouds.yaml
@@ -1,0 +1,5 @@
+clouds:
+{% for cloud in clouds %}
+  {{ cloud }}:
+    {{ secrets.clouds[cloud] | to_nice_yaml(indent=2) | indent(4) }}
+{% endfor %}

--- a/secrets.yml.example
+++ b/secrets.yml.example
@@ -3,18 +3,27 @@ secrets:
   nodepool:
     db_user: nodepool
     db_password: changeme
-    providers:
-      clouds:
-        cicloud:
-          auth:
-            auth_url: http://devstack.local/identity_admin
-            username: demo
-            user_domain_id: default
-            project_name: demo
-            project_domain_id: default
-            password: password
-          identity_api_version: '3'
-          region_name: RegionOne
   datadog:
     api_key: demokeyhash
     ansible_app_key: demoapphash
+  clouds:
+    bastioncloud:
+      auth:
+        auth_url: http://devstack.local/identity_admin
+        username: bastion
+        user_domain_id: default
+        project_name: bastion
+        project_domain_id: default
+        password: password
+      identity_api_version: '3'
+      region_name: RegionOne
+    cicloud:
+      auth:
+        auth_url: http://devstack.local/identity_admin
+        username: demo
+        user_domain_id: default
+        project_name: demo
+        project_domain_id: default
+        password: password
+      identity_api_version: '3'
+      region_name: RegionOne


### PR DESCRIPTION
This moves nodepool's cloud provider credentials out of its bucket
in secrets.yml and into a new clouds bucket, where we can manage
all of our clouds centrally.

This also adds a new reusable os-clouds role that can be used to write
out clouds.yaml containing data for specified clouds.

The bastion and nodepool roles have been updated to use it as a dependency.

Closes #35 