### PR TITLE
Allow configuring statsd in zuul

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -42,5 +42,6 @@
   tags: ['nodepool']
   roles:
     - role: nodepool
+      nodepool_statsd_enable: yes
       nodepool_providers:
         - nodepool-provider1

--- a/install-ci.yml
+++ b/install-ci.yml
@@ -31,6 +31,7 @@
         - monitoring
     - role: zuul
       zuul_gearman_server_start: false
+      zuul_statsd_enable: yes
     - role: dd-zuul
       tags:
         - monitoring

--- a/roles/nodepool/defaults/main.yml
+++ b/roles/nodepool/defaults/main.yml
@@ -2,3 +2,7 @@ nodepool_source_dir: /opt/source/nodepool
 nodepool_venv_dir: /opt/venvs/nodepool
 nodepool_mysql_host: localhost
 nodepool_providers: []
+
+nodepool_statsd_enable: no
+nodepool_statsd_host: 127.0.0.1
+nodepool_statsd_port: 8125

--- a/roles/nodepool/tasks/main.yml
+++ b/roles/nodepool/tasks/main.yml
@@ -50,6 +50,14 @@
   notify:
     - Restart nodepool
 
+- name: Install statsd
+  pip:
+    name: "{{ item }}"
+    virtualenv: "{{ nodepool_venv_dir }}"
+  with_items:
+    - statsd
+  when: nodepool_statsd_enable
+
 - name: Create nodepool dirs
   file:
     group: nodepool

--- a/roles/nodepool/templates/etc/default/nodepool
+++ b/roles/nodepool/templates/etc/default/nodepool
@@ -1,1 +1,8 @@
+# {{ ansible_managed }}
+
 PREFIX={{ nodepool_venv_dir }}
+
+{% if nodepool_statsd_enable %}
+STATSD_HOST={{ nodepool_statsd_host }}
+STATSD_PORT={{ nodepool_statsd_port }}
+{% endif %}

--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -9,3 +9,7 @@ zuul_gearman_port: 4730
 zuul_gearman_server_start: true
 zuul_gearman_server_log_config: /etc/zuul/gearman-logging.conf
 zuul_gearman_server_listen_address: 127.0.0.1
+
+zuul_statsd_enable: no
+zuul_statsd_host: 127.0.0.1
+zuul_statsd_port: 8125

--- a/roles/zuul/tasks/main.yml
+++ b/roles/zuul/tasks/main.yml
@@ -61,6 +61,14 @@
     - { name: 'jenkins-job-builder', version: '1.6.1' }
     - { name: 'pyzmq' }
 
+- name: Install statsd
+  pip:
+    name: "{{ item }}"
+    virtualenv: "{{ zuul_venv_dir }}"
+  with_items:
+    - statsd
+  when: zuul_statsd_enable
+
 - name: Install zuul config
   template:
     src: etc/zuul/zuul.conf

--- a/roles/zuul/templates/etc/default/zuul
+++ b/roles/zuul/templates/etc/default/zuul
@@ -1,3 +1,8 @@
 # {{ ansible_managed }}
 
 PREFIX={{ zuul_venv_dir }}
+
+{% if zuul_statsd_enable %}
+STATSD_HOST={{ zuul_statsd_host }}
+STATSD_PORT={{ zuul_statsd_port }}
+{% endif %}


### PR DESCRIPTION
Zuul can be configured to report statistics to statsd, of which datadog
can receive. Allow the zuul role to configure stats.