### PR TITLE
Use full datadog mysql integration

### DIFF
--- a/roles/dd-mysql/defaults/main.yml
+++ b/roles/dd-mysql/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+dd_mysql_user: datadog
+dd_mysql_password: "d@t@d0gPa$$"
+
+dd_mysql_replication: false
+dd_mysql_galera_cluster: false
+dd_mysql_extra_status_metrics: true
+dd_mysql_extra_innodb_metrics: true
+dd_mysql_extra_performance_metrics: true
+dd_mysql_schema_size_metrics: false
+dd_mysql_disable_innodb_metrics: false

--- a/roles/dd-mysql/meta/main.yml
+++ b/roles/dd-mysql/meta/main.yml
@@ -1,9 +1,18 @@
 ---
 dependencies:
   - role: dd-checks
-    datadog_fragments:
-      - type: process
-        name: mysql
+    datadog_checks:
+      mysql:
         instances:
-          - name: mysql
-            search_string: ['mysqld']
+          - server: localhost
+            user: "{{ dd_mysql_user }}"
+            pass: "{{ dd_mysql_password }}"
+
+            options:
+              replication: "{{ dd_mysql_replication }}"
+              galera_cluster: "{{ dd_mysql_galera_cluster }}"
+              extra_status_metrics: "{{ dd_mysql_extra_status_metrics }}"
+              extra_innodb_metrics: "{{ dd_mysql_extra_innodb_metrics }}"
+              extra_performance_metrics: "{{ dd_mysql_extra_performance_metrics }}"
+              schema_size_metrics: "{{ dd_mysql_schema_size_metrics }}"
+              disable_innodb_metrics: "{{ dd_mysql_disable_innodb_metrics }}"

--- a/roles/dd-mysql/tasks/main.yml
+++ b/roles/dd-mysql/tasks/main.yml
@@ -1,12 +1,8 @@
 ---
-- name: create monitor for mysqld process check
-  datadog_monitor:
-    api_key: "{{ secrets.datadog.api_key }}"
-    app_key: "{{ secrets.datadog.ansible_app_key }}"
-    name: mysqld process from ansible
+- name: datadog mysql user
+  mysql_user:
+    name: "{{ dd_mysql_user }}"
+    host: localhost
+    password: "{{ dd_mysql_password }}"
+    priv: "*.*:REPLICATION CLIENT,PROCESS/performance_schema.*:SELECT"
     state: present
-    type: "service check"
-    message: "mysql is down"
-    query: '"process.up".over("host:{{ ansible_hostname }}","process:mysql").last(3).count_by_status()'
-  vars:
-    ansible_python_interpreter: /opt/datadog/bin/python


### PR DESCRIPTION
Create a datadog user and grant it sufficient permissions to read
performance statistics and report it back via the datadog mysql
integration.