### PR TITLE
Add datadog check for the zuul merger count

### DIFF
--- a/roles/dd-zuul/tasks/main.yml
+++ b/roles/dd-zuul/tasks/main.yml
@@ -3,3 +3,14 @@
     src: zuul_server.py
     dest: "{{ datadog_file_dir }}/zuul_server.py"
   notify: restart dd-agent
+- name: monitor zuul merger count
+  datadog_monitor:
+    api_key: "{{ secrets.datadog.api_key }}"
+    app_key: "{{ secrets.datadog.ansible_app_key }}"
+    name: zuul merger count
+    state: present
+    type: "service check"
+    message: "no zuul mergers"
+    query: 'min(last_5m):avg:gearman.workers_by_task{host:zuul,task:merger:merge} < 1'
+  vars:
+    ansible_python_interpreter: /opt/datadog/bin/python


### PR DESCRIPTION
If there are no zuul mergers connected to the zuul server, create
a datadog warning. Also rename the previous status.json check to
differentiate it from this check.