### PR TITLE
Add more templating variables to dd-agent

### DIFF
--- a/roles/dd-agent/defaults/main.yml
+++ b/roles/dd-agent/defaults/main.yml
@@ -1,1 +1,3 @@
 ---
+datadog_use_dogstatsd: yes
+datadog_dogstatsd_port: 8125

--- a/roles/dd-agent/defaults/main.yml
+++ b/roles/dd-agent/defaults/main.yml
@@ -1,4 +1,1 @@
 ---
-dd_agent:
-  frags:
-    - process

--- a/roles/dd-agent/templates/etc/dd-agent/datadog.conf
+++ b/roles/dd-agent/templates/etc/dd-agent/datadog.conf
@@ -23,11 +23,15 @@ dd_url: https://app.datadoghq.com
 # (default: None, the agent doesn't start without it)
 api_key: {{ secrets.datadog.api_key }}
 
+{% if datadog_hostname is defined %}
 # Force the hostname to whatever you want. (default: auto-detected)
-# hostname: mymachine.mydomain
+hostname: {{ datadog_hostname }}
+{% endif %}
 
+{% if datadog_tags is defined %}
 # Set the host's tags (optional)
-# tags: mytag, env:prod, role:database
+tags: {{ datadog_tags | join(", ") }}
+{% endif %}
 
 # Set timeout in seconds for outgoing requests to Datadog. (default: 20)
 # When a request timeout, it will be retried after some time.
@@ -73,7 +77,7 @@ gce_updated_hostname: yes
 # graphite_listen_port: 17124
 
 # Additional directory to look for Datadog checks (optional)
-# additional_checksd: /etc/dd-agent/checks.d/
+additional_checksd: {{ datadog_file_dir }}
 
 # Allow non-local traffic to this Agent
 # This is required when using this Agent as a proxy for other Agents
@@ -140,10 +144,10 @@ gce_updated_hostname: yes
 # ========================================================================== #
 
 # If you don't want to enable the DogStatsd server, set this option to no
-# use_dogstatsd: yes
+use_dogstatsd: {{ datadog_use_dogstatsd | ternary('yes', 'no') }}
 
 #  Make sure your client is sending to the same port.
-# dogstatsd_port: 8125
+dogstatsd_port: {{ datadog_dogstatsd_port }}
 
 # By default dogstatsd will post aggregate metrics to the Agent (which handles
 # errors/timeouts/retries/etc). To send directly to the datadog api, set this


### PR DESCRIPTION
There are a number of other things here that should be able to be provided
via variable rather than hardcoded into config files.