### PR TITLE
Allow setting datadog log level

### DIFF
--- a/roles/dd-agent/defaults/main.yml
+++ b/roles/dd-agent/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 datadog_use_dogstatsd: yes
 datadog_dogstatsd_port: 8125
+
+datadog_log_level: INFO

--- a/roles/dd-agent/templates/etc/dd-agent/datadog.conf
+++ b/roles/dd-agent/templates/etc/dd-agent/datadog.conf
@@ -237,7 +237,7 @@ dogstatsd_port: {{ datadog_dogstatsd_port }}
 # Logging
 # ========================================================================== #
 
-# log_level: INFO
+log_level: {{ datadog_log_level }}
 
 # collector_log_file: /var/log/datadog/collector.log
 # forwarder_log_file: /var/log/datadog/forwarder.log


### PR DESCRIPTION
Datadog allow setting log_level which you can set to debug for more
information from the agent. Expose this via ansible role.