### PR TITLE
Add _meta back to dynamic inventory

### DIFF
--- a/inventory/openstack.py
+++ b/inventory/openstack.py
@@ -164,6 +164,7 @@ def get_host_groups_from_cloud(inventory):
                     append_hostvars(
                         hostvars, groups, server['id'], server,
                         namegroup=True)
+    groups['_meta'] = {'hostvars': hostvars}
     return groups
 
 


### PR DESCRIPTION
In commit 0b5d9569e3c6e3ecf3775eaf3c68310c69ca1068 we removed the _meta
key from the inventory. However it's the meta key that provides the IP
addresses and other connection information that we use to actually
contact the servers. Without meta we end up getting errors when trying
to connect to UUID hosts.

Revert the change to this file.