### PR TITLE
Consistently set ACLs on secrets and password file

### DIFF
--- a/roles/ansible-runner/tasks/main.yml
+++ b/roles/ansible-runner/tasks/main.yml
@@ -95,7 +95,18 @@
     - ansible_runner_secrets_path_stat.stat.exists
     - ansible_runner_secrets_path_stat.stat.isreg
 
-- name: ensure runner can read file
+- name: ensure secrets base acl
+  acl:
+    name: "{{ ansible_runner_secrets_path }}"
+    etype: mask
+    permissions: r
+    follow: no
+    state: present
+  when:
+    - ansible_runner_secrets_path_stat.stat.exists
+    - ansible_runner_secrets_path_stat.stat.isreg
+
+- name: ensure runner can read secrets
   acl:
     name: "{{ ansible_runner_secrets_path }}"
     entity: "{{ ansible_runner_user }}"
@@ -114,7 +125,7 @@
       path: "{{ ansible_runner_vault_password_file }}"
     register: ansible_runner_vault_password_file_path_stat
 
-  - name: ensure secrets owner
+  - name: ensure vault password owner
     file:
       state: file
       path: "{{ ansible_runner_vault_password_file }}"
@@ -125,7 +136,18 @@
       - ansible_runner_vault_password_file_path_stat.stat.exists
       - ansible_runner_vault_password_file_path_stat.stat.isreg
 
-  - name: ensure runner can read file
+  - name: ensure vault password base acl
+    acl:
+      name: "{{ ansible_runner_vault_password_file }}"
+      etype: mask
+      permissions: r
+      follow: no
+      state: present
+    when:
+      - ansible_runner_vault_password_file_path_stat.stat.exists
+      - ansible_runner_vault_password_file_path_stat.stat.isreg
+
+  - name: ensure runner can read vault password
     acl:
       name: "{{ ansible_runner_vault_password_file }}"
       entity: "{{ ansible_runner_user }}"

--- a/roles/ansible-runner/tasks/main.yml
+++ b/roles/ansible-runner/tasks/main.yml
@@ -79,86 +79,15 @@
     owner: "{{ ansible_runner_user }}"
     group: www-data
 
-- name: check secrets exist
-  stat:
-    path: "{{ ansible_runner_secrets_path }}"
-  register: ansible_runner_secrets_path_stat
+- include: secret-file.yml
+  secret_file_type: secrets
+  secret_file_path: "{{ ansible_runner_secrets_path }}"
+  secret_file_user: "{{ ansible_runner_user }}"
 
-- name: ensure secrets owner
-  file:
-    state: file
-    path: "{{ ansible_runner_secrets_path }}"
-    mode: 0400
-    owner: root
-    group: root
-  when:
-    - ansible_runner_secrets_path_stat.stat.exists
-    - ansible_runner_secrets_path_stat.stat.isreg
-
-- name: ensure secrets base acl
-  acl:
-    name: "{{ ansible_runner_secrets_path }}"
-    etype: mask
-    permissions: r
-    follow: no
-    state: present
-  when:
-    - ansible_runner_secrets_path_stat.stat.exists
-    - ansible_runner_secrets_path_stat.stat.isreg
-
-- name: ensure runner can read secrets
-  acl:
-    name: "{{ ansible_runner_secrets_path }}"
-    entity: "{{ ansible_runner_user }}"
-    etype: user
-    follow: no
-    permissions: r
-    state: present
-  when:
-    - ansible_runner_secrets_path_stat.stat.exists
-    - ansible_runner_secrets_path_stat.stat.isreg
-    - ansible_runner_user != 'root'
-
-- block:
-  - name: check vault password exist
-    stat:
-      path: "{{ ansible_runner_vault_password_file }}"
-    register: ansible_runner_vault_password_file_path_stat
-
-  - name: ensure vault password owner
-    file:
-      state: file
-      path: "{{ ansible_runner_vault_password_file }}"
-      mode: 0400
-      owner: root
-      group: root
-    when:
-      - ansible_runner_vault_password_file_path_stat.stat.exists
-      - ansible_runner_vault_password_file_path_stat.stat.isreg
-
-  - name: ensure vault password base acl
-    acl:
-      name: "{{ ansible_runner_vault_password_file }}"
-      etype: mask
-      permissions: r
-      follow: no
-      state: present
-    when:
-      - ansible_runner_vault_password_file_path_stat.stat.exists
-      - ansible_runner_vault_password_file_path_stat.stat.isreg
-
-  - name: ensure runner can read vault password
-    acl:
-      name: "{{ ansible_runner_vault_password_file }}"
-      entity: "{{ ansible_runner_user }}"
-      etype: user
-      follow: no
-      permissions: r
-      state: present
-    when:
-      - ansible_runner_vault_password_file_path_stat.stat.exists
-      - ansible_runner_vault_password_file_path_stat.stat.isreg
-      - ansible_runner_user != 'root'
+- include: secret-file.yml
+  secret_file_type: vault password
+  secret_file_path: "{{ ansible_runner_vault_password_file }}"
+  secret_file_user: "{{ ansible_runner_user }}"
   when: ansible_runner_vault_password_file is defined
 
 - name: Add ansible-runner cron job

--- a/roles/ansible-runner/tasks/secret-file.yml
+++ b/roles/ansible-runner/tasks/secret-file.yml
@@ -1,0 +1,39 @@
+- name: check {{ secret_file_type }} exist
+  stat:
+    path: "{{ secret_file_path }}"
+  register: secret_file_path_stat
+
+- name: ensure {{ secret_file_type }} owner
+  file:
+    state: file
+    path: "{{ secret_file_path }}"
+    mode: 0400
+    owner: root
+    group: root
+  when:
+    - secret_file_path_stat.stat.exists
+    - secret_file_path_stat.stat.isreg
+
+- name: ensure {{ secret_file_type }} base acl
+  acl:
+    name: "{{ secret_file_path }}"
+    etype: mask
+    permissions: r
+    follow: no
+    state: present
+  when:
+    - secret_file_path_stat.stat.exists
+    - secret_file_path_stat.stat.isreg
+
+- name: ensure runner can read vault password
+  acl:
+    name: "{{ secret_file_path }}"
+    entity: "{{ secret_file_user }}"
+    etype: user
+    follow: no
+    permissions: r
+    state: present
+  when:
+    - secret_file_path_stat.stat.exists
+    - secret_file_path_stat.stat.isreg
+    - secret_file_user != 'root'


### PR DESCRIPTION
Fix problem of cideploy not being able to read password file and make the way
these settings are applied more consistent.