### PR TITLE
Set the datadog-mysql password from secrets

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -16,6 +16,7 @@
   roles:
     - role: mysql
     - role: dd-mysql
+      dd_mysql_password: "{{ secrets.datadog.mysql_password }}"
       tags:
         - monitoring
     - role: databases

--- a/secrets.yml.example
+++ b/secrets.yml.example
@@ -6,6 +6,7 @@ secrets:
   datadog:
     api_key: demokeyhash
     ansible_app_key: demoapphash
+    mysql_password: demomysqlpass
   clouds:
     bastioncloud:
       auth:


### PR DESCRIPTION
We don't want to use the default password for the datadog user to access
the mysql database. Use one from secrets.