### PR TITLE
Use well known names for gearman and mysql

### DIFF
--- a/inventory/host_vars/nodepool.bonncyi.portbleu.com
+++ b/inventory/host_vars/nodepool.bonncyi.portbleu.com
@@ -1,0 +1,4 @@
+nodepool_mysql_host: zuul.bonncyi.portbleu.com
+nodepool_gearman_servers:
+  - host: zuul.bonnyci.portbleu.com
+    port: 4730


### PR DESCRIPTION
Rather than use ansible to determine the IP for gearman and mysql lets
manage it manually for specific hosts. This will simplify things whilst
we have a small number of servers.