### PR TITLE
Zuul gearman server listen on open IP.

### DIFF
--- a/inventory/host_vars/nodepool.bonncyi.portbleu.com
+++ b/inventory/host_vars/nodepool.bonncyi.portbleu.com
@@ -1,3 +1,5 @@
+gearman_bind_address: 0.0.0.0
+
 nodepool_mysql_host: zuul.bonncyi.portbleu.com
 nodepool_gearman_servers:
   - host: zuul.bonnyci.portbleu.com


### PR DESCRIPTION
Gearman needs to be listening on a public interface so that nodepool can
connect to it.