### PR TITLE
Set gearman listener on correct host

### DIFF
--- a/inventory/host_vars/nodepool.bonnyci.portbleu.com
+++ b/inventory/host_vars/nodepool.bonnyci.portbleu.com
@@ -1,5 +1,3 @@
-gearman_bind_address: 0.0.0.0
-
 nodepool_mysql_host: zuul.bonnyci.portbleu.com
 nodepool_gearman_servers:
   - host: zuul.bonnyci.portbleu.com

--- a/inventory/host_vars/zuul.bonnyci.portbleu.com
+++ b/inventory/host_vars/zuul.bonnyci.portbleu.com
@@ -1,0 +1,1 @@
+gearman_bind_address: 0.0.0.0


### PR DESCRIPTION
The gearman server is running on the zuul node, not the nodepool node
and so we have to set the listener in the correct host_vars.