### PR TITLE
Add noop jobs to the doc project

### DIFF
--- a/roles/zuul/templates/etc/zuul/config/layout.yaml
+++ b/roles/zuul/templates/etc/zuul/config/layout.yaml
@@ -44,4 +44,14 @@ pipelines:
 
 jobs: []
 
-projects: []
+project-templates:
+  - name: noop-jobs
+    check:
+      - noop
+    gate:
+      - noop
+
+projects:
+  - name: doc
+    template:
+      - name: noop-jobs


### PR DESCRIPTION
Create a noop-jobs template and use it in the doc project.