### PR TITLE
Move our CI config in to group_vars/all, use internal zuul hostname

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -31,15 +31,6 @@
       tags:
         - monitoring
     - role: zuul
-      zuul_gearman_server_start: false
-      zuul_statsd_enable: yes
-      zuul_connections:
-        portbleu:
-          driver: gerrit
-          port: 29418
-          server: review.portbleu.com
-          sshkey: /var/lib/zuul/.ssh/id_rsa
-          user: bonnyci
     - role: dd-zuul
       tags:
         - monitoring

--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -1,2 +1,16 @@
-nodepool_mysql_host: 192.168.3.164
 ansible_runner_vault_password_file: /etc/vault_pass.txt
+
+nodepool_mysql_host: zuul.bonnyci-internal.portbleu.com
+nodepool_gearman_servers:
+  - host: zuul.bonnyci-internal.portbleu.com
+    port: 4730
+
+zuul_gearman_server_start: false
+zuul_statsd_enable: yes
+zuul_connections:
+  portbleu:
+    driver: gerrit
+    port: 29418
+    server: review.portbleu.com
+    sshkey: /var/lib/zuul/.ssh/id_rsa
+    user: bonnyci

--- a/inventory/host_vars/nodepool.bonnyci.portbleu.com
+++ b/inventory/host_vars/nodepool.bonnyci.portbleu.com
@@ -1,4 +1,0 @@
-nodepool_mysql_host: zuul.bonnyci.portbleu.com
-nodepool_gearman_servers:
-  - host: zuul.bonnyci.portbleu.com
-    port: 4730


### PR DESCRIPTION
Right now were defining config vars in 3 different places. Lets just use
the one file for now until we need to add some more complexity. Also
switch us to use the internal hostname for reaching mysql.