### PR TITLE
Don't insert inverted commas into zuul.conf

### DIFF
--- a/roles/zuul/templates/etc/zuul/zuul.conf
+++ b/roles/zuul/templates/etc/zuul/zuul.conf
@@ -19,7 +19,7 @@ start = {{ zuul_gearman_server_start }}
 [connection github]
 driver=github
 sshkey=/var/lib/zuul/.ssh/id_rsa
-api_token= "{{secrets.zuul_github_api_key}}"
+api_token={{secrets.zuul_github_api_key}}
 
 [zuul]
 layout_config = /etc/zuul/config/layout.yaml


### PR DESCRIPTION
When you add inverted commas in the ini file these are eventually
interpretted and sent as part of the auth token to github leading to
Unauthenticated responses. We don't need the inverted commas in an ini
file.