### PR TITLE
Use full path to logfile destination

### DIFF
--- a/roles/nodepool/templates/etc/nodepool/logging.conf
+++ b/roles/nodepool/templates/etc/nodepool/logging.conf
@@ -18,12 +18,12 @@ handlers=debug_hand
 [handler_main_hand]
 class=FileHandler
 formatter=main_format
-args=('{{ item }}.log', 'w')
+args=('/var/log/nodepool/{{ item }}.log', 'w')
 
 [handler_debug_hand]
 class=FileHandler
 formatter=main_format
-args=('{{ item }}_debug.log', 'w')
+args=('/var/log/nodepool/{{ item }}_debug.log', 'w')
 
 [formatter_main_format]
 format=F1 %(asctime)s %(levelname)s %(message)s


### PR DESCRIPTION
These configs don't have a base path for logfile locations, and are
assumed to be relative to /.