### PR TITLE
Dont use console log in zuul logging config

### DIFF
--- a/roles/zuul/templates/etc/zuul/logging.conf
+++ b/roles/zuul/templates/etc/zuul/logging.conf
@@ -3,14 +3,14 @@
 keys=root,zuul,gerrit,gear
 
 [handlers]
-keys=console,debug,normal
+keys=debug,normal
 
 [formatters]
 keys=simple
 
 [logger_root]
 level=WARNING
-handlers=console
+handlers=normal
 
 [logger_zuul]
 level=DEBUG
@@ -26,12 +26,6 @@ qualname=gerrit
 level=DEBUG
 handlers=debug,normal
 qualname=gear
-
-[handler_console]
-level=WARNING
-class=StreamHandler
-formatter=simple
-args=(sys.stdout,)
 
 [handler_debug]
 level=DEBUG


### PR DESCRIPTION
We dont use the console logger but we were still specifying it.