### PR TITLE
Add root logger to nodepool logging config

### DIFF
--- a/roles/nodepool/templates/etc/nodepool/logging.conf
+++ b/roles/nodepool/templates/etc/nodepool/logging.conf
@@ -1,31 +1,31 @@
 [loggers]
-keys=main,debug
+keys=root,debug
 
 [handlers]
-keys=main_hand,debug_hand
+keys=root_hand,debug_hand
 
-[formatters]
-keys=main_format
+formatters]
+keys=root_format
 
-[logger_main]
+[logger_root]
 level=WARN
-handlers=main_hand
+handlers=root_hand
 
 [logger_debug]
 level=DEBUG
 handlers=debug_hand
 
-[handler_main_hand]
+[handler_root_hand]
 class=FileHandler
-formatter=main_format
-args=('/var/log/nodepool/{{ item }}.log', 'w')
+formatter=root_format
+args=('{{ item }}.log', 'w')
 
 [handler_debug_hand]
 class=FileHandler
-formatter=main_format
-args=('/var/log/nodepool/{{ item }}_debug.log', 'w')
+formatter=root_format
+args=('{{ item }}_debug.log', 'w')
 
-[formatter_main_format]
+[formatter_root_format]
 format=F1 %(asctime)s %(levelname)s %(message)s
 datefmt=
 class=logging.Formatter


### PR DESCRIPTION
You must specify a root logger when doing python logging. Lets rename
main to root.