### PR TITLE
Fix debug logging and formatter in nodepool logging

### DIFF
--- a/roles/nodepool/templates/etc/nodepool/logging.conf
+++ b/roles/nodepool/templates/etc/nodepool/logging.conf
@@ -1,29 +1,25 @@
 [loggers]
-keys=root,debug
+keys=root
 
 [handlers]
 keys=root_hand,debug_hand
 
-formatters]
+[formatters]
 keys=root_format
 
 [logger_root]
 level=WARN
-handlers=root_hand
-
-[logger_debug]
-level=DEBUG
-handlers=debug_hand
+handlers=root_hand,debug_hand
 
 [handler_root_hand]
 class=FileHandler
 formatter=root_format
-args=('{{ item }}.log', 'w')
+args=('/var/log/nodepool/{{ item }}.log', 'w')
 
 [handler_debug_hand]
 class=FileHandler
 formatter=root_format
-args=('{{ item }}_debug.log', 'w')
+args=('/var/log/nodepool/{{ item }}_debug.log', 'w')
 
 [formatter_root_format]
 format=F1 %(asctime)s %(levelname)s %(message)s


### PR DESCRIPTION
We had a few no-brainer bugs in our nodepool logging config.