### PR TITLE
Turn on debug logs for nodepool

### DIFF
--- a/roles/nodepool/templates/etc/nodepool/logging.conf
+++ b/roles/nodepool/templates/etc/nodepool/logging.conf
@@ -17,6 +17,7 @@ formatter=root_format
 args=('/var/log/nodepool/{{ item }}.log', 'w')
 
 [handler_debug_hand]
+level=DEBUG
 class=FileHandler
 formatter=root_format
 args=('/var/log/nodepool/{{ item }}_debug.log', 'w')


### PR DESCRIPTION
We dropped the debug log level from the debug logs by accident.