### PR TITLE
Remove needless zuul restart notify

### DIFF
--- a/roles/zuul/tasks/main.yml
+++ b/roles/zuul/tasks/main.yml
@@ -94,7 +94,6 @@
     src: etc/zuul/config/layout.yaml
     dest: /etc/zuul/config/layout.yaml
     owner: zuul
-  notify: Restart zuul
 
 - name: Install job definitions
   copy:


### PR DESCRIPTION
Zuul polls layout.yaml for changes and automatically applies changes,
we do not need to restart zuul for changes to the layout to take effect.