### PR TITLE
Add a test that just does ci all in one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
 env:
   - TEST_RUN="ansible-playbook -i herp, bastion.yml install-ci.yml provision.yml tests/validate-ci.yml --syntax-check"
   - TEST_RUN="ansible-playbook -i inventory/allinone bastion.yml install-ci.yml tests/validate-ci.yml -c docker -vv -e @secrets.yml.example -e ansible_become=no --skip-tags ddapi"
+  - TEST_RUN="ansible-playbook -i inventory/allinone install-ci.yml tests/validate-ci.yml -c docker -vv -e @secrets.yml.example -e ansible_become=no --skip-tags ddapi"
 
 before_install:
 - docker pull ubuntu:xenial


### PR DESCRIPTION
We were mixing bastion and ci in the same allinone host, which was
masking errors in the ci plays. This splits out the ci into it's own
stand alone test.

Later PRs will split things further making individual containers for
zuul and nodepool for more segregated testing.