### PR TITLE
Use infra logging config

### DIFF
--- a/roles/nodepool/templates/etc/nodepool/logging.conf
+++ b/roles/nodepool/templates/etc/nodepool/logging.conf
@@ -1,28 +1,44 @@
 [loggers]
-keys=root
+keys=root,nodepool,requests
 
 [handlers]
-keys=root_hand,debug_hand
+keys=console,debug,normal
 
 [formatters]
-keys=root_format
+keys=simple
 
 [logger_root]
-level=WARN
-handlers=root_hand,debug_hand
+level=WARNING
+handlers=console
 
-[handler_root_hand]
-class=FileHandler
-formatter=root_format
-args=('/var/log/nodepool/{{ item }}.log', 'w')
+[logger_requests]
+level=WARNING
+handlers=debug,normal
+qualname=requests
 
-[handler_debug_hand]
+[logger_nodepool]
 level=DEBUG
-class=FileHandler
-formatter=root_format
-args=('/var/log/nodepool/{{ item }}_debug.log', 'w')
+handlers=debug,normal
+qualname=nodepool
 
-[formatter_root_format]
-format=F1 %(asctime)s %(levelname)s %(message)s
+[handler_console]
+level=WARNING
+class=StreamHandler
+formatter=simple
+args=(sys.stdout,)
+
+[handler_debug]
+level=DEBUG
+class=logging.handlers.TimedRotatingFileHandler
+formatter=simple
+args=('/var/log/nodepool/{{ item }}_debug.log', 'H', 8, 30,)
+
+[handler_normal]
+level=INFO
+class=logging.handlers.TimedRotatingFileHandler
+formatter=simple
+args=('/var/log/nodepool/{{ item }}.log', 'H', 8, 30,)
+
+[formatter_simple]
+format=%(asctime)s %(levelname)s %(name)s: %(message)s
 datefmt=
-class=logging.Formatter


### PR DESCRIPTION
Our logging config is causing nodepool to hang, but with a mostly
straight copy of infra's config things seem to work.