### PR TITLE
Fix pip upgrade nodepool constantly registering "changed"

### DIFF
--- a/roles/nodepool/tasks/main.yml
+++ b/roles/nodepool/tasks/main.yml
@@ -59,9 +59,9 @@
 
 - name: Install nodepool
   pip:
-    extra_args: -U
     name: "{{ nodepool_source_dir }}"
     virtualenv: "{{ nodepool_venv_dir }}"
+    state: latest
   notify:
     - Restart nodepool
 


### PR DESCRIPTION
Currently, the pip module is using extra_args to pass the -U flag,
thereby upgrading any packages as necessary. A side-effect of this is
that any time extra_args is used, the task will be marked "changed",
regardless if changes actually occurred.

Switching this to using "ensure: latest" has the same effect, but the
pip module has enough info to do its job and only register changes if
changes actually happen.