### PR TITLE
Add nodepool-base element to set up nodes

### DIFF
--- a/roles/nodepool/defaults/main.yml
+++ b/roles/nodepool/defaults/main.yml
@@ -26,6 +26,7 @@ nodepool_diskimages:
       - growroot
       - openssh-server
       - devuser
+      - bonnyci-nodepool
     release: xenial
     env-vars:
       DIB_DEV_USER_USERNAME: bonnyci

--- a/roles/nodepool/files/etc/nodepool/elements/bonnyci-nodepool/README.rst
+++ b/roles/nodepool/files/etc/nodepool/elements/bonnyci-nodepool/README.rst
@@ -1,0 +1,5 @@
+================
+bonnyci-nodepool
+================
+
+Basic filesystem and preperation for running a node as a nodepool element.

--- a/roles/nodepool/files/etc/nodepool/elements/bonnyci-nodepool/finalise.d/99-nodepool-dir
+++ b/roles/nodepool/files/etc/nodepool/elements/bonnyci-nodepool/finalise.d/99-nodepool-dir
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright (C) 2011-2013 OpenStack Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# dib-lint: disable=setu setpipefail
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -e
+
+# Nodepool expects this dir to exist when it boots slaves.
+# Nodepool writes environment info to this dir. We set the mode
+# to 0777 so that any user can access this env info.
+mkdir /etc/nodepool
+chmod 0777 /etc/nodepool

--- a/roles/nodepool/tasks/main.yml
+++ b/roles/nodepool/tasks/main.yml
@@ -86,6 +86,18 @@
     - /etc/nodepool/scripts
     - /var/log/nodepool
 
+# This should be maintained in a project-config repo. At very least this should
+# be a synchronize but that doesn't work in our docker based testing. Fudge it
+# for now.
+- name: Copy elements
+  copy:
+    src: "files/etc/nodepool/elements/{{ item }}"
+    dest: /etc/nodepool/elements/
+    owner: nodepool
+    group: nodepool
+  with_items:
+    - bonnyci-nodepool
+
 - name: Write config
   template:
     src: "etc/nodepool/{{ item }}"


### PR DESCRIPTION
The nodepool builder requires an /etc/nodepool folder on the hosts.
Create a nodepool-base element that does this and can be used for other
future configs.