### PR TITLE
Set dib elements executable

### DIFF
--- a/roles/nodepool/tasks/main.yml
+++ b/roles/nodepool/tasks/main.yml
@@ -98,6 +98,13 @@
   with_items:
     - bonnyci-nodepool
 
+- name: set elements executable
+  file:
+    path: "/etc/nodepool/elements/{{ item }}"
+    mode: 0755
+  with_items:
+    - bonnyci-nodepool/finalise.d/99-nodepool-dir
+
 - name: Write config
   template:
     src: "etc/nodepool/{{ item }}"


### PR DESCRIPTION
These are defined as executable in the git repo but when ansible does
the copy it copies them as regular files. Set them as executable until
we have a better strategy for copying these over.