### PR TITLE
Fix nodepool pip install to only run with new commits

### DIFF
--- a/roles/nodepool/tasks/main.yml
+++ b/roles/nodepool/tasks/main.yml
@@ -56,14 +56,15 @@
     dest: "{{ nodepool_source_dir }}"
     repo: https://git.openstack.org/openstack-infra/nodepool
     version: master
+  register: nodepool_git
 
 - name: Install nodepool
   pip:
     name: "{{ nodepool_source_dir }}"
     virtualenv: "{{ nodepool_venv_dir }}"
     state: latest
-  notify:
-    - Restart nodepool
+  when: nodepool_git.changed
+  notify: Restart nodepool
 
 - name: Install statsd
   pip:


### PR DESCRIPTION
Currently, the pip task attempts a 'pip install --upgrade' on nodepool
every run. The pip module is apparently not smart enough to see that
there are no changes run-to-run, even if the code has not changed. This
is triggering the restart handler every time pip runs, so nodepool is
restarting every 15 minutes.

Now, pip will only be run if there are new commits to nodepool.
(the zuul role has this same pattern)