### PR TITLE
Add ansible to missing pip reqs for zuul role

### DIFF
--- a/roles/zuul/tasks/main.yml
+++ b/roles/zuul/tasks/main.yml
@@ -61,6 +61,7 @@
   with_items:
     - { name: 'jenkins-job-builder', version: '1.6.1' }
     - { name: 'pyzmq' }
+    - { name: 'ansible' }
 
 - name: Install statsd
   pip:


### PR DESCRIPTION
Looks like zuul-launcher needs ansible