### PR TITLE
Completely remove ubuntu-trusty image from nodepool

### DIFF
--- a/inventory/group_vars/allinone
+++ b/inventory/group_vars/allinone
@@ -7,10 +7,6 @@ nodepool_providers:
     cloud: cicloud
     max-servers: 10
     images:
-      - name: ubuntu-trusty
-        min-ram: 2048
-        diskimage: ubuntu-trusty
-        private-key: /var/lib/nodepool/.ssh/id_rsa
       - name: ubuntu-xenial
         min-ram: 2048
         diskimage: ubuntu-xenial

--- a/roles/nodepool/defaults/main.yml
+++ b/roles/nodepool/defaults/main.yml
@@ -33,11 +33,6 @@ nodepool_diskimages:
       DIB_DEV_USER_AUTHORIZED_KEYS: /var/lib/nodepool/.ssh/id_rsa.pub
 
 nodepool_labels:
-  - name: ubuntu-trusty
-    image: ubuntu-trusty
-    min-ready: 1
-    providers:
-      - name: cicloud
   - name: ubuntu-xenial
     image: ubuntu-xenial
     min-ready: 1


### PR DESCRIPTION
The ubuntu-trusty image was partially removed from the nodepool configuration,
remove the remaining bits of config for the node type.