### PR TITLE
Remove cache update for dd-agent-related packages (changed: true)

### DIFF
--- a/roles/dd-agent/tasks/main.yml
+++ b/roles/dd-agent/tasks/main.yml
@@ -13,8 +13,6 @@
   apt:
     name: "{{ item }}"
     state: installed
-    update_cache: yes
-    cache_valid_time: 30
   with_items:
     - apt-transport-https
 
@@ -22,8 +20,6 @@
   apt:
     name: datadog-agent
     state: installed
-    update_cache: yes
-    cache_valid_time: 30
   notify:
     - restart dd-agent
 


### PR DESCRIPTION
Currently, every cideply run marks these tasks as "changed: true"
because the cache is updated. This is actually a bug in Ansible 2.2
(https://github.com/ansible/ansible-modules-core/issues/5484).

Since the cache is updated by the repo installation right above it,
the cache doesn't need updated for the dependencies/dd-agent installs,
since their status is "state: present", and hence will only be installed
the first time, not upgraded.