### PR TITLE
Add zmq-publishers to nodepool

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -63,6 +63,8 @@
       nodepool_statsd_enable: yes
       nodepool_mysql_user: "{{ secrets.nodepool.db_user }}"
       nodepool_mysql_password: "{{ secrets.nodepool.db_password }}"
+      nodepool_zmq_publishers:
+        - tcp://zuul.bonnyci-internal.portbleu.com:8888
 
 - name: Install logging
   hosts: log

--- a/roles/nodepool/defaults/main.yml
+++ b/roles/nodepool/defaults/main.yml
@@ -17,6 +17,9 @@ nodepool_gearman_servers:
   - host: 127.0.0.1
     port: 4730
 
+nodepool_zmq_publishers:
+  - tcp://localhost:8888
+
 nodepool_diskimages:
   - name: ubuntu-xenial
     elements:

--- a/roles/nodepool/templates/etc/nodepool/nodepool.yaml
+++ b/roles/nodepool/templates/etc/nodepool/nodepool.yaml
@@ -16,6 +16,9 @@ labels:
 providers:
 {{ nodepool_providers | to_nice_yaml(indent=2) }}
 
+zmq-publishers:
+{{ nodepool_zmq_publishers | to_nice_yaml(indent=2) }}
+
 targets:
   - name: zuul
     assign-via-gearman: True


### PR DESCRIPTION
Hey! What do you know, there's another communication mechanism between
nodepool and zuul where nodepool listens for things like onFinalized
which is the thing that deletes the nodes when a job is finished.

Seriously. We need to get this under control.