### PR TITLE
Set zuul merger url

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -30,6 +30,7 @@
       tags:
         - monitoring
     - role: zuul
+      zuul_merger_url: http://zuul.bonnyci-internal.portbleu.com/p
     - role: dd-zuul
       tags:
         - monitoring

--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -14,6 +14,8 @@ zuul_statsd_enable: no
 zuul_statsd_host: 127.0.0.1
 zuul_statsd_port: 8125
 
+zuul_merger_url: 127.0.0.1
+
 zuul_connections:
   gerrit:
     driver: gerrit

--- a/roles/zuul/templates/etc/zuul/zuul.conf
+++ b/roles/zuul/templates/etc/zuul/zuul.conf
@@ -41,4 +41,4 @@ username = bonnyci
 git_dir = /var/lib/zuul/git
 log_config = /etc/zuul/merger-logging.conf
 pidfile = /var/run/zuul-merger/zuul-merger.pid
-zuul_url = 127.0.0.1
+zuul_url = {{ zuul_merger_url }}


### PR DESCRIPTION
The zuul merger clones the base repository from the original source to
take load off the merger servers and then takes the change ref from the
merger. We need to point the zuul merger url at this url.