### PR TITLE
Remove the ssh-agent handling from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 
 before_install:
 - docker pull ubuntu:xenial
-- docker run -d --name allinone --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v $SSH_AUTH_SOCK:/ssh-agent --env SSH_AUTH_SOCK=/ssh-agent ubuntu:xenial systemd
+- docker run -d --name allinone --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro ubuntu:xenial systemd
 - docker exec -i allinone apt-get update
 - docker exec -i allinone apt-get install -y python-apt ca-certificates apt-transport-https sudo ssh
 


### PR DESCRIPTION
The ssh agent handling was to allow forwarding the ssh keys that would
allow travis to deploy from a github enterprise account. This isn't need
and doesn't seem to be available on public travis workers.