### PR TITLE
Publish logs from echo-true job

### DIFF
--- a/roles/zuul/files/jobs/echotrue.yaml
+++ b/roles/zuul/files/jobs/echotrue.yaml
@@ -4,3 +4,6 @@
 
     builders:
       - shell: echo true
+
+    publishers:
+      - console-log


### PR DESCRIPTION
Just because it doesn't do anything doesn't mean we don't want to
publish logs from the echo-true job.