### PR TITLE
Give merger a git user name and email

### DIFF
--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -12,5 +12,8 @@ zuul_connections:
     driver: github
     api_token: "{{ secrets.zuul_github_api_key }}"
 
+zuul_git_user_email: anne@bonnyci.org
+zuul_git_user_name: Anne Bonny
+
 bastion_clouds:
   - contra-sjc

--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -15,6 +15,8 @@ zuul_statsd_host: 127.0.0.1
 zuul_statsd_port: 8125
 
 zuul_merger_url: 127.0.0.1
+zuul_git_user_name: user@domain.io
+zuul_git_user_email: My Name
 
 zuul_connections:
   gerrit:

--- a/roles/zuul/templates/etc/zuul/zuul.conf
+++ b/roles/zuul/templates/etc/zuul/zuul.conf
@@ -42,3 +42,5 @@ git_dir = /var/lib/zuul/git
 log_config = /etc/zuul/merger-logging.conf
 pidfile = /var/run/zuul-merger/zuul-merger.pid
 zuul_url = {{ zuul_merger_url }}
+git_user_email = {{ zuul_git_user_email }}
+git_user_name = {{ zuul_git_user_name }}


### PR DESCRIPTION
Sometimes merger will have to create a merge commit, which will require
having a configured git user name and email address. This commit
provides a method for supplying such information on a site by site bases
through role defaults. It also sets something reasonable for our BonnyCI
implementation.

Fixes BonnyCI/projman#61