### PR TITLE
Add zookeeper to nodepool host

### DIFF
--- a/inventory/ci
+++ b/inventory/ci
@@ -7,5 +7,8 @@ zuul.bonnyci-internal.portbleu.com
 [mysql]
 zuul.bonnyci-internal.portbleu.com
 
+[zookeeper]
+nodepool.bonnyci-internal.portbleu.com
+
 [log]
 logs.bonnyci-internal.portbleu.com


### PR DESCRIPTION
We didn't add zookeeper to the nodepool host so it's not actually there.