### PR TITLE
Remove --no-images from nodepool commands

### DIFF
--- a/roles/nodepool/files/etc/systemd/system/nodepool-deleter.service
+++ b/roles/nodepool/files/etc/systemd/system/nodepool-deleter.service
@@ -7,7 +7,7 @@ Type=simple
 User=nodepool
 Group=nodepool
 EnvironmentFile=-/etc/default/nodepool
-ExecStart=/bin/sh -c "${PREFIX}/bin/nodepoold -d --no-builder --no-launches --no-images --no-webapp -l /etc/nodepool/nodepool-deleter_logging.conf"
+ExecStart=/bin/sh -c "${PREFIX}/bin/nodepoold -d --no-builder --no-launches --no-webapp -l /etc/nodepool/nodepool-deleter_logging.conf"
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/nodepool/files/etc/systemd/system/nodepool-launcher.service
+++ b/roles/nodepool/files/etc/systemd/system/nodepool-launcher.service
@@ -7,7 +7,7 @@ Type=simple
 User=nodepool
 Group=nodepool
 EnvironmentFile=-/etc/default/nodepool
-ExecStart=/bin/sh -c "${PREFIX}/bin/nodepoold -d --no-builder --no-deletes --no-images --no-webapp -l /etc/nodepool/nodepool-launcher_logging.conf"
+ExecStart=/bin/sh -c "${PREFIX}/bin/nodepoold -d --no-builder --no-deletes --no-webapp -l /etc/nodepool/nodepool-launcher_logging.conf"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
--no-images seems to have been removed from nodepool and it prevents the
delete and launcher being started.