### PR TITLE
Remove script-dir from nodepool config

### DIFF
--- a/roles/nodepool/tasks/main.yml
+++ b/roles/nodepool/tasks/main.yml
@@ -33,7 +33,6 @@
   with_items:
     - /etc/nodepool
     - /etc/nodepool/elements
-    - /etc/nodepool/scripts
     - /opt/nodepool/images
     - /var/log/nodepool
 

--- a/roles/nodepool/templates/etc/nodepool/nodepool.yaml
+++ b/roles/nodepool/templates/etc/nodepool/nodepool.yaml
@@ -2,7 +2,6 @@
 
 elements-dir: /etc/nodepool/elements
 images-dir: /opt/nodepool/images
-script-dir: /etc/nodepool/scripts
 
 zookeeper-servers:
 {{ nodepool_zookeeper_servers | to_nice_yaml(indent=2) }}


### PR DESCRIPTION
Upstream removed script-dir from configuration which broke our
deployment scripts because we test the config file with
config-validator.

Upstream: https://review.openstack.org/#/c/411999/
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>