### PR TITLE
Add a nodepool check to datadog

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -76,6 +76,9 @@
       nodepool_mysql_password: "{{ secrets.nodepool.db_password }}"
       nodepool_zmq_publishers:
         - tcp://zuul.bonnyci-internal.portbleu.com:8888
+    - role: dd-nodepool
+      tags:
+        - monitoring
 
 - name: Install logging
   hosts: log

--- a/roles/dd-nodepool/defaults/main.yml
+++ b/roles/dd-nodepool/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+dd_nodepool_status_url:  http://locahost:8005/image-list

--- a/roles/dd-nodepool/files/nodepool_server.py
+++ b/roles/dd-nodepool/files/nodepool_server.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import requests
+
+from checks import AgentCheck
+
+class NodepoolCheck(AgentCheck):
+
+    SERVICE_CHECK_NAME = 'nodepool_server.got_status'
+
+    def check(self, instance):
+        if 'status_url' not in instance:
+            self.log.info("Skipping instance, no url found.")
+            return
+
+        status_url = instance['status_url']
+        default_timeout = self.init_config.get('default_timeout', 5)
+        timeout = float(instance.get('timeout', default_timeout))
+        service_check_tags = ['url:%s' % status_url]
+        
+        try:
+            self.get_nodepool_status(status_url, timeout, service_check_tags)
+        except Exception as e:
+            self.service_check(self.SERVICE_CHECK_NAME,
+                               AgentCheck.CRITICAL,
+                               message=str(e),
+                               tags=service_check_tags)
+
+    def get_nodepool_status(self, status_url, timeout, service_check_tags):
+        r = requests.get(status_url, timeout=timeout)
+
+        if r.status_code != 200:
+            self.service_check(
+                self.SERVICE_CHECK_NAME,
+                AgentCheck.UNKNOWN,
+                message='Unexpected status code: %d' % r.status_code,
+                tags=service_check_tags)
+
+            return
+
+        self.service_check(self.SERVICE_CHECK_NAME,
+                           AgentCheck.OK,
+                           message='Received status from %s' % status_url,
+                           tags=service_check_tags)

--- a/roles/dd-nodepool/meta/main.yml
+++ b/roles/dd-nodepool/meta/main.yml
@@ -1,0 +1,8 @@
+---
+dependencies:
+  - role: dd-checks
+
+    datadog_checks:
+      nodepool_server: 
+        instances:
+          - status_url: "{{ dd_nodepool_status_url }}"

--- a/roles/dd-nodepool/tasks/main.yml
+++ b/roles/dd-nodepool/tasks/main.yml
@@ -1,0 +1,5 @@
+- name: install nodepool check
+  copy:
+    src: nodepool_server.py
+    dest: "{{ datadog_file_dir }}/nodepool_server.py"
+  notify: restart dd-agent


### PR DESCRIPTION
This will add a datadog check for the nodepool status page.

This time with license info!