### PR TITLE
Always update DIB

### DIFF
--- a/roles/nodepool/tasks/main.yml
+++ b/roles/nodepool/tasks/main.yml
@@ -90,6 +90,12 @@
     owner: root
     content: "nodepool ALL=(ALL) NOPASSWD:ALL"
 
+- name: Ensure latest diskimage-builder
+  pip:
+    name: diskimage-builder
+    virtualenv: "{{ nodepool_venv_dir }}"
+    state: latest
+
 - name: Git clone nodepool
   git:
     dest: "{{ nodepool_source_dir }}"


### PR DESCRIPTION
We want to make sure that we are always running the latest
diskimage-builder because we are likely going to be making a lot of last
minute fixes there.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>