### PR TITLE
Add url_pattern to zuul.conf

### DIFF
--- a/roles/zuul/templates/etc/zuul/zuul.conf
+++ b/roles/zuul/templates/etc/zuul/zuul.conf
@@ -30,6 +30,7 @@ layout_config = /etc/zuul/config/layout.yaml
 log_config = /etc/zuul/server-logging.conf
 pidfile = /var/run/zuul-server/zuul-server.pid
 state_dir = /var/lib/zuul
+url_pattern = https://logs.bonnyci.com/{build.parameters['LOG_PATH']}
 
 [launcher]
 jenkins_jobs=/var/lib/zuul/jobs


### PR DESCRIPTION
If a url_pattern is set, zuul will use it to generate a link to the logs
in success and failure comments.

Signed-off-by: K Jonathan Harker <jonathan.harker@ibm.com>