### PR TITLE
Use service reload to recheck zuul-server config

### DIFF
--- a/roles/zuul/handlers/main.yml
+++ b/roles/zuul/handlers/main.yml
@@ -2,6 +2,15 @@
 - name: Reload systemd units
   command: systemctl daemon-reload
 
+- name: check zuul-server is running
+  command: pgrep zuul-server
+  register: zuul_check_running
+  changed_when: false
+  failed_when: zuul_check_running.rc == 127
+  listen:
+    - Restart zuul
+    - Reload zuul-server
+
 - name: Restart zuul
   service:
     name: "{{ item }}"
@@ -10,9 +19,11 @@
     - zuul-launcher
     - zuul-merger
     - zuul-server
-  when: zuul_allow_restart_services | bool
+  when: zuul_check_running.rc == 0 and (zuul_allow_restart_services | bool)
+  register: zuul_restarted
 
 - name: Reload zuul-server
-  command: pkill --signal SIGHUP zuul-server
-  register: pkill
-  failed_when: pkill | failed and pkill.rc != 1
+  service:
+    name: zuul-server
+    state: reloaded
+  when: zuul_check_running.rc == 0 and (zuul_restarted is not defined or not zuul_restarted.changed)

--- a/roles/zuul/templates/etc/default/zuul
+++ b/roles/zuul/templates/etc/default/zuul
@@ -1,7 +1,5 @@
 # {{ ansible_managed }}
 
-PREFIX={{ zuul_venv_dir }}
-
 PATH={{ zuul_venv_dir }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 {% if zuul_statsd_enable %}
 STATSD_HOST={{ zuul_statsd_host }}

--- a/roles/zuul/templates/etc/systemd/system/zuul.service
+++ b/roles/zuul/templates/etc/systemd/system/zuul.service
@@ -8,7 +8,7 @@ User=zuul
 Group=zuul
 LimitNOFILE=8192
 EnvironmentFile=-/etc/default/{{ item }}
-ExecStart=/bin/sh -c "${PREFIX}/bin/{{ item }} -d"
+ExecStart={{ zuul_venv_dir }}/bin/{{ item }} -d
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]


### PR DESCRIPTION
There are two threads started by zuul-server, the main scheduler thread
and a gearman server thread. By using pkill to reload the zuul-server
configuration we are also sending SIGHUP to the gearman thread which
doesn't know how to handle the signal, dies, and generally causes a
bunch of problems.

We've already added an ExecReload= to the zuul-server systemd unit file
which we want to use instead to trigger a config refresh, however
because we use /bin/sh -c "..." in ExecStart the $MAINPID that we are
sending the SIGHUP to is the sh process which will kill the service.

To fix this we remove the /bin/sh in ExecStart= which means we can no
longer use ${PREFIX} because the path to the initial exec in a unit file
must be absolute and this causes an error.

After all this we should be able to have ansible correctly execute a
layout update without crashing zuul-server.

Closes: BonnyCI/projman#62
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>