### PR TITLE
Use python2 for dib images

### DIFF
--- a/roles/nodepool/defaults/main.yml
+++ b/roles/nodepool/defaults/main.yml
@@ -41,6 +41,7 @@ nodepool_diskimages:
     env-vars:
       DIB_DEV_USER_USERNAME: bonnyci
       DIB_DEV_USER_AUTHORIZED_KEYS: /etc/nodepool/slave-authorized-keys
+      DIB_PYTHON_VERSION: 2
 
 nodepool_labels:
   - name: ubuntu-xenial


### PR DESCRIPTION
zuul-cloner is currently only compatible with python2 so ensure the
pip/virtualenv that dib sets up is in python2

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>