### PR TITLE
Make the DIB_PYTHON_VERSION a string

### DIFF
--- a/roles/nodepool/defaults/main.yml
+++ b/roles/nodepool/defaults/main.yml
@@ -41,7 +41,7 @@ nodepool_diskimages:
     env-vars:
       DIB_DEV_USER_USERNAME: bonnyci
       DIB_DEV_USER_AUTHORIZED_KEYS: /etc/nodepool/slave-authorized-keys
-      DIB_PYTHON_VERSION: 2
+      DIB_PYTHON_VERSION: '2'
 
 nodepool_labels:
   - name: ubuntu-xenial


### PR DESCRIPTION
So all ENV variables need to be strings. This really should be something
that nodepool should handle but for now make sure that everything we
pass are strings.