### PR TITLE
Fixup status log path

### DIFF
--- a/roles/zuul/templates/etc/zuul/zuul.conf
+++ b/roles/zuul/templates/etc/zuul/zuul.conf
@@ -30,7 +30,7 @@ layout_config = /etc/zuul/config/layout.yaml
 log_config = /etc/zuul/server-logging.conf
 pidfile = /var/run/zuul-server/zuul-server.pid
 state_dir = /var/lib/zuul
-url_pattern = https://logs.bonnyci.com/{build.parameters['LOG_PATH']}
+url_pattern = http://logs.bonnyci.com/{build.parameters[LOG_PATH]}
 
 [launcher]
 jenkins_jobs=/var/lib/zuul/jobs


### PR DESCRIPTION
When formatting a URL pattern you don't need to string quote dictionary
keys. So we can have to do parameters[LOG_PATH] to find the expected
parameter.

Also remove the https prefix. We don't have SSL yet.