### PR TITLE
Remove another https link to logs url

### DIFF
--- a/roles/zuul/templates/etc/zuul/config/layout.yaml
+++ b/roles/zuul/templates/etc/zuul/config/layout.yaml
@@ -21,7 +21,7 @@ pipelines:
     success:
       github:
         status: true
-        status_url: &log_link https://logs.bonnyci.com/{pipeline.name}/{change.project.name}/{change.number}/{item.enqueue_time}
+        status_url: &log_link http://logs.bonnyci.com/{pipeline.name}/{change.project.name}/{change.number}/{item.enqueue_time}/
         comment: false
     failure:
       github:


### PR DESCRIPTION
Remove a previously missed https url to logs.bonnyci.com. We don't
support https on the log server.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>