### PR TITLE
Add python3-dev to nodepool image

### DIFF
--- a/roles/nodepool/files/etc/nodepool/elements/bonnyci-nodepool/package-installs.yml
+++ b/roles/nodepool/files/etc/nodepool/elements/bonnyci-nodepool/package-installs.yml
@@ -1,4 +1,5 @@
 build-essential:
 python-dev:
+python3-dev:
 libssl-dev:
 libffi-dev:


### PR DESCRIPTION
Zuul specifies that the pep8 tox venv uses python3, so we need
python3-dev to install the pep8 dependencies.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>