### PR TITLE
Move tox venv location out of the working dir

### DIFF
--- a/roles/zuul/files/jobs/tox.yaml
+++ b/roles/zuul/files/jobs/tox.yaml
@@ -5,8 +5,10 @@
     builders:
       - zuul-git-prep
       - shell: |
-          virtualenv venv
-          source venv/bin/activate
+          tmpdir=$(mktemp -d)
+          trap "rm -rf $tmpdir" EXIT
+          virtualenv $tmpdir/venv
+          source $tmpdir/venv/bin/activate
           pip install tox
           tox -e py27,pep8
 


### PR DESCRIPTION
Create a temp directory for the virtualenv instead of creating it in the
working directory to avoid pep8 errors from dependencies.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>