### PR TITLE
Enable sudo access to bonnyci user

### DIFF
--- a/roles/nodepool/defaults/main.yml
+++ b/roles/nodepool/defaults/main.yml
@@ -41,6 +41,7 @@ nodepool_diskimages:
     env-vars:
       DIB_DEV_USER_USERNAME: bonnyci
       DIB_DEV_USER_AUTHORIZED_KEYS: /etc/nodepool/slave-authorized-keys
+      DIB_DEV_USER_PWDLESS_SUDO: Yes
       DIB_PYTHON_VERSION: '2'
 
 nodepool_labels:


### PR DESCRIPTION
We may in future want to remove this but for now we need a way for the
CI user to install there own packages.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>