### PR TITLE
Make DIB_USER_PWDLESS_SUDO a string

### DIFF
--- a/roles/nodepool/defaults/main.yml
+++ b/roles/nodepool/defaults/main.yml
@@ -41,7 +41,7 @@ nodepool_diskimages:
     env-vars:
       DIB_DEV_USER_USERNAME: bonnyci
       DIB_DEV_USER_AUTHORIZED_KEYS: /etc/nodepool/slave-authorized-keys
-      DIB_DEV_USER_PWDLESS_SUDO: Yes
+      DIB_DEV_USER_PWDLESS_SUDO: 'Yes'
       DIB_PYTHON_VERSION: '2'
 
 nodepool_labels:


### PR DESCRIPTION
So this one's less obvious than the integer. Ansible converts Yes into a
boolean true and python injects it into the env variables as a bool.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>