### PR TITLE
Add the start of a multinode hoist role.

### DIFF
--- a/roles/nodepool/defaults/main.yml
+++ b/roles/nodepool/defaults/main.yml
@@ -50,6 +50,13 @@ nodepool_labels:
     min-ready: 1
     providers:
       - name: cicloud
+  - name: ubuntu-hoist
+    image: ubuntu-xenial
+    min-ready: 0
+    subnodes: 2
+    ready-script: subnode-ssh.sh
+    providers:
+      - name: cicloud
 
 nodepool_providers:
   - name: cicloud

--- a/roles/nodepool/files/etc/nodepool/elements/bonnyci-nodepool/extra-data.d/60-copy-nodepool-scripts
+++ b/roles/nodepool/files/etc/nodepool/elements/bonnyci-nodepool/extra-data.d/60-copy-nodepool-scripts
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# dib-lint: disable=setu setpipefail
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -e
+
+# Copy the scripts from the nodepool script dir into the staging directory.
+cp -ar /etc/nodepool/scripts $TMP_HOOKS_PATH/nodepool-scripts

--- a/roles/nodepool/files/etc/nodepool/elements/bonnyci-nodepool/post-install.d/60-install-nodepool-scripts
+++ b/roles/nodepool/files/etc/nodepool/elements/bonnyci-nodepool/post-install.d/60-install-nodepool-scripts
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# dib-lint: disable=setu setpipefail
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -e
+
+# always make the nodepool-scripts directory even if nothing goes in it
+mkdir -p /opt/nodepool-scripts
+
+# copy the scripts from the stagin directory into the image
+if [ -d /tmp/in_target.d/nodepool-scripts ]; then
+   cp -ar /tmp/in_target.d/nodepool-scripts/* /opt/nodepool-scripts/
+fi
+
+# set the correct folder permissions
+chown -R root:root /opt/nodepool-scripts
+chmod -R a+rX /opt/nodepool-scripts

--- a/roles/nodepool/files/etc/nodepool/scripts/subnode-ssh.sh
+++ b/roles/nodepool/files/etc/nodepool/scripts/subnode-ssh.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -xe
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# When setting up subnodes nodepool will drop an ssh key and information into
+# /etc/nodepool. This doesn't actually set the nodes up to communicate with
+# each other though. This script just copies the ssh keys from /etc/nodepool
+# into the appropriate authorized_keys and ssh directories.
+
+ROLE=`cat /etc/nodepool/role`
+
+
+function sub_node {
+    # allow login to the subnode from the primary
+    cat /etc/nodepool/id_rsa.pub >> ~/.ssh/authorized_keys
+}
+
+
+function primary_node {
+    # install the ssh key into the user
+    cp /etc/nodepool/id_rsa /etc/nodepool/id_rsa.pub ~/.ssh
+    chmod 600 ~/.ssh/id_rsa ~/.ssh/id_rsa.pub
+}
+
+
+if [[ "$ROLE" == "sub" ]]; then
+    sub_node
+elif [[ "$ROLE" == "primary" ]]; then
+    primary_node
+else
+    echo "Script failure. Unknown role: $ROLE"
+    exit 1
+fi

--- a/roles/nodepool/tasks/main.yml
+++ b/roles/nodepool/tasks/main.yml
@@ -32,7 +32,6 @@
     mode: 0755
   with_items:
     - /etc/nodepool
-    - /etc/nodepool/elements
     - /opt/nodepool/images
     - /var/log/nodepool
 
@@ -120,10 +119,10 @@
   when: nodepool_statsd_enable
 
 # This should be maintained in a project-config repo.
-- name: Copy elements
+- name: Copy nodepool configuration
   synchronize:
-    src: files/etc/nodepool/elements/
-    dest: /etc/nodepool/elements/
+    src: files/etc/nodepool/
+    dest: /etc/nodepool/
     rsync_opts:
       - "--chown=nodepool:nodepool"
 

--- a/roles/zuul/files/jobs/hoist.yaml
+++ b/roles/zuul/files/jobs/hoist.yaml
@@ -1,0 +1,17 @@
+- job:
+    name: ubuntu-hoist
+    node: 'ubuntu-hoist'
+
+    builders:
+      - zuul-git-prep
+      - shell: |
+          tmpdir=$(mktemp -d)
+          trap "rm -rf $tmpdir" EXIT
+          virtualenv $tmpdir/venv
+          source $tmpdir/venv/bin/activate
+          pip install ansible
+          pip install -r requirements.txt
+          # more to add here
+
+    publishers:
+      - console-log

--- a/roles/zuul/templates/etc/zuul/config/layout.yaml
+++ b/roles/zuul/templates/etc/zuul/config/layout.yaml
@@ -64,7 +64,7 @@ jobs:
 projects:
   - name: BonnyCI/hoist
     check_github:
-      - echo-true
+      - ubuntu-hoist
     gate_github:
       - echo-true
 


### PR DESCRIPTION
To make multinode jobs work we seem to need a few things. First we need
a new node label in nodepool defining the layout.

After that we need to set up the new hosts to be able to ssh amongst
themselves by copying the generated ssh keys into place after nodepool
has started. This is done via nodepool scripts which are pre-baked into
an image.

Then we add the job definition and add it to a pipeline.

As it is it doesn't do anything. The next step will be to do a dynamic
ansible inventory that reads hosts out of /etc/nodepool/subnodes and
start to run the hoist role against it.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>