### PR TITLE
Keyscan the subnodes to prevent first connection problems

### DIFF
--- a/roles/nodepool/files/etc/nodepool/scripts/subnode-ssh.sh
+++ b/roles/nodepool/files/etc/nodepool/scripts/subnode-ssh.sh
@@ -30,6 +30,9 @@ function primary_node {
     # install the ssh key into the user
     cp /etc/nodepool/id_rsa /etc/nodepool/id_rsa.pub ~/.ssh
     chmod 600 ~/.ssh/id_rsa ~/.ssh/id_rsa.pub
+
+    # put the subnodes into known_hosts
+    ssh-keyscan -H -f /etc/nodepool/sub_nodes >> ~/.ssh/known_hosts
 }
 
 


### PR DESCRIPTION
We almost certainly want to ssh to our sub_nodes so set up there ssh
keys in known_hosts to prevent being prompted.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>