### PR TITLE
List the ssl directory in the hoist job

### DIFF
--- a/roles/zuul/files/jobs/hoist.yaml
+++ b/roles/zuul/files/jobs/hoist.yaml
@@ -7,9 +7,11 @@
       - shell: |
           tmpdir=$(mktemp -d)
           trap "rm -rf $tmpdir" EXIT
+          dpkg -s ca-certificates
+          ls /etc/ssl/certs
           virtualenv $tmpdir/venv
           source $tmpdir/venv/bin/activate
-          pip install ansible
+          pip install git+https://github.com/jamielennox/ansible.git@ssl-testing#egg=ansible
           pip install -r requirements.txt
           ansible-playbook -i inventory/nodepool.py install-ci.yml --skip-tags monitoring -e @secrets.yml.example
 


### PR DESCRIPTION
Hoist jobs started from cold VMs fail very early because they can't
validate SSL certificates. List the expected directory in the test
output to see if there's anything there.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>