### PR TITLE
Add haveged nodepool element

### DIFF
--- a/roles/nodepool/defaults/main.yml
+++ b/roles/nodepool/defaults/main.yml
@@ -35,6 +35,7 @@ nodepool_diskimages:
       - growroot
       - openssh-server
       - devuser
+      - haveged
       - pip-and-virtualenv
       - bonnyci-nodepool
     release: xenial

--- a/roles/nodepool/files/etc/nodepool/elements/haveged/README.rst
+++ b/roles/nodepool/files/etc/nodepool/elements/haveged/README.rst
@@ -1,0 +1,11 @@
+=======
+haveged
+=======
+
+Install and enable the haveged service.
+
+In virtual machines we often have a problem with randomness particularly at
+early stages. This will start and enable the haveged service which adds
+additional entropy to the kernel. This should not be installed on production
+systems however is safe for things like a CI system where the results aren't
+super valuable.

--- a/roles/nodepool/files/etc/nodepool/elements/haveged/element-deps
+++ b/roles/nodepool/files/etc/nodepool/elements/haveged/element-deps
@@ -1,0 +1,2 @@
+dib-init-system
+package-installs

--- a/roles/nodepool/files/etc/nodepool/elements/haveged/package-installs.yaml
+++ b/roles/nodepool/files/etc/nodepool/elements/haveged/package-installs.yaml
@@ -1,0 +1,1 @@
+haveged:

--- a/roles/nodepool/files/etc/nodepool/elements/haveged/post-install.d/80-enable-haveged-service
+++ b/roles/nodepool/files/etc/nodepool/elements/haveged/post-install.d/80-enable-haveged-service
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+case "$DIB_INIT_SYSTEM" in
+    systemd)
+        systemctl enable haveged.service
+        ;;
+    *)
+        echo "Unsupported init system $DIB_INIT_SYSTEM"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
When booting a new imaage there is not enough entropy in to perform
basic crypto operations like downloading from https. We can solve this
in virutal machines by starting and enabling the haveged service.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>