### PR TITLE
Remove the -vvvv from hoist jobs

### DIFF
--- a/roles/zuul/files/jobs/hoist.yaml
+++ b/roles/zuul/files/jobs/hoist.yaml
@@ -11,7 +11,7 @@
           source $tmpdir/venv/bin/activate
           pip install ansible
           pip install -r requirements.txt
-          ansible-playbook -vvvv -i inventory/nodepool.py install-ci.yml --skip-tags monitoring -e @secrets.yml.example
+          ansible-playbook -i inventory/nodepool.py install-ci.yml --skip-tags monitoring -e @secrets.yml.example
 
     publishers:
       - console-log


### PR DESCRIPTION
The -vvvv produces so much output you can't see the problem. Remove
verboes completely for now and we can add it back if needed.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>