### PR TITLE
Use bash as the bonnyci user shell

### DIFF
--- a/inventory/group_vars/nodepool
+++ b/inventory/group_vars/nodepool
@@ -16,5 +16,6 @@ nodepool_diskimages:
       DIB_DEV_USER_USERNAME: bonnyci
       DIB_DEV_USER_AUTHORIZED_KEYS: /etc/nodepool/slave-authorized-keys
       DIB_DEV_USER_PWDLESS_SUDO: 'Yes'
+      DIB_DEV_USER_SHELL: /bin/bash
       DIB_NODEPOOL_SCRIPT_DIR: /etc/nodepool/scripts
       DIB_PYTHON_VERSION: '2'


### PR DESCRIPTION
Using sh is so outdated. Let's use bash instead.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>