### PR TITLE
Use become_user instead of ansible_user in validate script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ matrix:
 
 env:
   - TEST_RUN="ansible-playbook -i herp, bastion.yml install-ci.yml provision.yml tests/validate-ci.yml --syntax-check"
-  - TEST_RUN="ansible-playbook -i inventory/allinone bastion.yml install-ci.yml tests/validate-ci.yml -c docker -vv -e @secrets.yml.example -e ansible_become=no --skip-tags ddapi"
-  - TEST_RUN="ansible-playbook -i inventory/allinone install-ci.yml tests/validate-ci.yml -c docker -vv -e @secrets.yml.example -e ansible_become=no --skip-tags ddapi"
+  - TEST_RUN="ansible-playbook -i inventory/allinone bastion.yml install-ci.yml tests/validate-ci.yml -c docker -vv -e @secrets.yml.example --skip-tags ddapi"
+  - TEST_RUN="ansible-playbook -i inventory/allinone install-ci.yml tests/validate-ci.yml -c docker -vv -e @secrets.yml.example --skip-tags ddapi"
   - TEST_RUN="python test/layout-checks.py job-list.txt"
   - TEST_RUN="test/signed-off-by-test.sh"
 

--- a/tests/validate-ci.yml
+++ b/tests/validate-ci.yml
@@ -36,11 +36,11 @@
       command: pgrep -f /opt/venvs/nodepool/bin/nodepoold
 
     - name: validate nodepool operation
+      become: yes
+      become_user: nodepool
       command: /opt/venvs/nodepool/bin/nodepool {{ item }}
       with_items:
         - config-validate
         - list
         - job-list
         - dib-image-list
-      vars:
-        - ansible_user: nodepool


### PR DESCRIPTION
By setting the ansible_user=nodepool you tell ansible to try and ssh
into the nodepool machine as the nodepool user. What we want is to
continue to ssh as the bonnyci user, but sudo to being the nodepool user
once on the machine. This is done via become.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>