### PR TITLE
Make nodepool and zuul logs available via tailon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ env:
   - TEST_RUN="tests/signed-off-by-test.sh"
 
 before_install:
-- docker pull ubuntu:xenial
-- docker run -d --name allinone --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro ubuntu:xenial systemd
-- docker exec -i allinone apt-get update
-- docker exec -i allinone apt-get install -y python-apt ca-certificates apt-transport-https sudo ssh
+  - docker pull ubuntu:xenial
+  - docker run -d --name allinone --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro ubuntu:xenial systemd
+  - docker exec -i allinone apt-get update
+  - docker exec -i allinone apt-get install -y python-apt ca-certificates apt-transport-https sudo ssh
 
 install:
   - pip install ansible

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -115,10 +115,13 @@ Vagrant.configure(2) do |config|
   config.vm.define :logs do |logs|
     logs.vm.hostname = 'logs.vagrant'
     logs.vm.network "private_network", ip: "10.0.0.102"
+    logs.hostmanager.aliases = %w(monitor.vagrant)
 
     logs.vm.provider "virtualbox" do |v|
       v.memory = '1024'
     end
+
+    logs.vm.network "forwarded_port", guest: 80, host: 8082
 
     logs.vm.provision "shell", path: "tools/install-pip.sh"
     logs.vm.provision "shell", path: "tools/vagrant-inject-pubkey.sh"
@@ -131,29 +134,6 @@ Vagrant.configure(2) do |config|
     logs.trigger.after :destroy do
       run "vagrant ssh bastion -c 'sudo -i -u cideploy ssh-keygen -f /home/cideploy/.ssh/known_hosts -R logs.vagrant'"
       run "vagrant ssh bastion -c 'sudo -i -u cideploy ssh-keygen -f /home/cideploy/.ssh/known_hosts -R 10.0.0.102'"
-    end
-  end
-
-  config.vm.define :monitor do |monitor|
-    monitor.vm.hostname = 'monitor.vagrant'
-    monitor.vm.network "private_network", ip: "10.0.0.103"
-    monitor.vm.network "forwarded_port", guest: 80, host: 8083
-
-    monitor.vm.provider "virtualbox" do |v|
-      v.memory = '1024'
-    end
-
-    monitor.vm.provision "shell", path: "tools/install-pip.sh"
-    monitor.vm.provision "shell", path: "tools/vagrant-inject-pubkey.sh"
-
-    monitor.trigger.after [:up, :provision] do
-      run "vagrant ssh bastion -c 'sudo -i -u cideploy ssh -o StrictHostKeyChecking=no ubuntu@monitor.vagrant true'"
-      run "vagrant ssh bastion -c 'sudo -i -u cideploy /vagrant/tools/vagrant-run-ansible.sh --limit monitor'"
-    end
-
-    monitor.trigger.after :destroy do
-      run "vagrant ssh bastion -c 'sudo -i -u cideploy ssh-keygen -f /home/cideploy/.ssh/known_hosts -R monitor.vagrant'"
-      run "vagrant ssh bastion -c 'sudo -i -u cideploy ssh-keygen -f /home/cideploy/.ssh/known_hosts -R 10.0.0.103'"
     end
   end
 

--- a/install-ci.yml
+++ b/install-ci.yml
@@ -55,6 +55,15 @@
       tags:
         - monitoring
 
+    - role: filebeat
+      filebeat_prospectors:
+        - input_type: log
+          paths:
+            - /var/log/zuul/gearman.log
+            - /var/log/zuul/launcher.log
+            - /var/log/zuul/merger.log
+            - /var/log/zuul/server.log
+
     - role: logrotate
       logrotate_configs:
         - name: zuul
@@ -74,11 +83,21 @@
     - role: nodepool
       nodepool_mysql_user: "{{ secrets.nodepool.db_user }}"
       nodepool_mysql_password: "{{ secrets.nodepool.db_password }}"
+
     - role: dd-nodepool
       tags:
         - monitoring
 
-- name: Install logging
+    - role: filebeat
+      filebeat_prospectors:
+        - input_type: log
+          paths:
+            - /var/log/nodepool/nodepool-builder.log
+            - /var/log/nodepool/nodepool-deleter.log
+            - /var/log/nodepool/nodepool-launcher.log
+            - /var/log/nodepool/nodepoold.log
+
+- name: Serve test-output logs
   hosts: log
   become: yes
   tags: ['logs']
@@ -95,3 +114,10 @@
     - role: dd-apache
       tags:
         - monitoring
+
+- name: Serve system logs
+  hosts: monitor
+  become: yes
+  tags: ['logs']
+  roles:
+    - role: monitor-system-logs

--- a/install-ci.yml
+++ b/install-ci.yml
@@ -9,6 +9,26 @@
       tags:
         - monitoring
 
+- name: Log server
+  hosts: log
+  become: yes
+  tags: ['logs']
+  roles:
+    - role: os-loganalyze
+      os_loganalyze_root_dir: "{{ bonnyci_logs_root_dir }}"
+      os_loganalyze_file_conditions: "{{ bonnyci_logs_loganalyze_file_conditions }}"
+
+    - role: monitor-system-logs
+
+    - role: apache
+      apache_apt_install: "{{ bonnyci_logs_apache_apt_install }}"
+      apache_mods_enabled: "{{ bonnyci_logs_apache_mods_install }}"
+      apache_vhosts: "{{ bonnyci_logs_apache_vhosts }}"
+
+    - role: dd-apache
+      tags:
+        - monitoring
+
 - name: Install mysql
   hosts: mysql
   become: yes
@@ -96,28 +116,3 @@
             - /var/log/nodepool/nodepool-deleter.log
             - /var/log/nodepool/nodepool-launcher.log
             - /var/log/nodepool/nodepoold.log
-
-- name: Serve test-output logs
-  hosts: log
-  become: yes
-  tags: ['logs']
-  roles:
-    - role: os-loganalyze
-      os_loganalyze_root_dir: "{{ bonnyci_logs_root_dir }}"
-      os_loganalyze_file_conditions: "{{ bonnyci_logs_loganalyze_file_conditions }}"
-
-    - role: apache
-      apache_apt_install: "{{ bonnyci_logs_apache_apt_install }}"
-      apache_mods_enabled: "{{ bonnyci_logs_apache_mods_install }}"
-      apache_vhosts: "{{ bonnyci_logs_apache_vhosts }}"
-
-    - role: dd-apache
-      tags:
-        - monitoring
-
-- name: Serve system logs
-  hosts: monitor
-  become: yes
-  tags: ['logs']
-  roles:
-    - role: monitor-system-logs

--- a/inventory/ci
+++ b/inventory/ci
@@ -13,11 +13,7 @@ nodepool.bonnyci-internal.portbleu.com
 [log]
 logs.bonnyci-internal.portbleu.com
 
-[monitor]
-monitor.bonnyci-internal.portbleu.com
-
 [production]
 nodepool.bonnyci-internal.portbleu.com
 zuul.bonnyci-internal.portbleu.com
 logs.bonnyci-internal.portbleu.com
-monitor.bonnyci-internal.portbleu.com

--- a/inventory/ci
+++ b/inventory/ci
@@ -13,7 +13,11 @@ nodepool.bonnyci-internal.portbleu.com
 [log]
 logs.bonnyci-internal.portbleu.com
 
+[monitor]
+monitor.bonnyci-internal.portbleu.com
+
 [production]
 nodepool.bonnyci-internal.portbleu.com
 zuul.bonnyci-internal.portbleu.com
 logs.bonnyci-internal.portbleu.com
+monitor.bonnyci-internal.portbleu.com

--- a/inventory/group_vars/log
+++ b/inventory/group_vars/log
@@ -2,6 +2,9 @@ bonnyci_logs_apache_apt_install:
   - libapache2-mod-wsgi
 
 bonnyci_logs_apache_mods_install:
+  - proxy.conf
+  - proxy.load
+  - proxy_http.load
   - rewrite.load
 
 bonnyci_logs_apache_vhosts:
@@ -68,6 +71,15 @@ bonnyci_logs_apache_vhosts:
       WSGIApplicationGroup %{GLOBAL}
 
       ServerSignature Off
+
+  - name: system-logs
+    server_name: "{{ bonnyci_system_logs_apache_server_name | default('monitor') }}"
+    document_root: /var/www/html/logstash
+    document_root_options: +FollowSymLinks
+    vhost_extra: |
+      AddType text/plain .log
+      Redirect permanent /system-logs /system-logs/
+      ProxyPass "/system-logs/" http://localhost:{{ tailon_port }}/system-logs/
 
 bonnyci_logs_loganalyze_file_conditions:
   - filename_pattern: ^.*\.txt(\.gz)?$

--- a/inventory/group_vars/multinode
+++ b/inventory/group_vars/multinode
@@ -4,9 +4,13 @@ bastion_clouds:
   - bastioncloud
 
 bonnyci_logs_apache_server_name: logs.multinode
+bonnyci_system_logs_apache_server_name: monitor.multinode
 bonnyci_zuul_apache_server_name: zuul.multinode
 
 datadog_enabled: no
+
+filebeat_output_logstash_hosts:
+  - "monitor.multinode:5044"
 
 nodepool_gearman_servers:
   - host: "{{ zuul_ip }}"

--- a/inventory/group_vars/production
+++ b/inventory/group_vars/production
@@ -4,6 +4,9 @@ bastion_clouds:
 bonnyci_logs_apache_server_name: logs.bonnyci.com
 bonnyci_zuul_apache_server_name: zuul.bonnyci.portbleu.com
 
+filebeat_output_logstash_hosts:
+  - "monitor.bonnyci-internal.portbleu.com:5044"
+
 nodepool_gearman_servers:
   - host: zuul.bonnyci-internal.portbleu.com
     port: 4730

--- a/inventory/group_vars/production
+++ b/inventory/group_vars/production
@@ -2,10 +2,11 @@ bastion_clouds:
   - contra-sjc
 
 bonnyci_logs_apache_server_name: logs.bonnyci.com
+bonnyci_system_logs_apache_server_name: monitor.bonnyci.com
 bonnyci_zuul_apache_server_name: zuul.bonnyci.portbleu.com
 
 filebeat_output_logstash_hosts:
-  - "monitor.bonnyci-internal.portbleu.com:5044"
+  - "logs.bonnyci-internal.portbleu.com:5044"
 
 nodepool_gearman_servers:
   - host: zuul.bonnyci-internal.portbleu.com

--- a/inventory/group_vars/production
+++ b/inventory/group_vars/production
@@ -20,7 +20,7 @@ nodepool_labels:
   - name: ubuntu-hoist
     image: ubuntu-xenial
     min-ready: 0
-    subnodes: 2
+    subnodes: 3
     ready-script: subnode-ssh.sh
     providers:
       - name: cicloud

--- a/inventory/group_vars/vagrant
+++ b/inventory/group_vars/vagrant
@@ -1,6 +1,10 @@
 bastion_clouds:
   - bastioncloud
 
+bonnyci_logs_apache_server_name: logs.vagrant
+bonnyci_system_logs_apache_server_name: monitor.vagrant
+bonnyci_zuul_apache_server_name: zuul.vagrant
+
 datadog_enabled: no
 
 filebeat_output_logstash_hosts:

--- a/inventory/group_vars/vagrant
+++ b/inventory/group_vars/vagrant
@@ -3,6 +3,9 @@ bastion_clouds:
 
 datadog_enabled: no
 
+filebeat_output_logstash_hosts:
+  - "monitor.vagrant:5044"
+
 hoist_repo: /vagrant/.git
 
 nodepool_providers:

--- a/inventory/host_vars/nodepool.vagrant
+++ b/inventory/host_vars/nodepool.vagrant
@@ -1,0 +1,1 @@
+zookeeper_myid: 1

--- a/inventory/nodepool.py
+++ b/inventory/nodepool.py
@@ -69,10 +69,10 @@ def get_inventory(subnodes):
     output['zookeeper'] = {'hosts': ['nodepool.multinode']}
     output['zuul'] = {'hosts': ['zuul.multinode']}
     output['mysql'] = {'hosts': ['zuul.multinode']}
-    #output['log'] = {'hosts': ['logs.multinode']}
+    output['log'] = {'hosts': ['logs.multinode']}
     output['multinode'] = {'hosts': ['nodepool.multinode',
                                      'zuul.multinode',
-                                     #'logs.multinode',
+                                     'logs.multinode',
                                      ]}
 
     return output

--- a/inventory/vagrant
+++ b/inventory/vagrant
@@ -13,9 +13,13 @@ zuul.vagrant ansible_user=ubuntu
 [log]
 logs.vagrant ansible_user=ubuntu
 
+[monitor]
+monitor.vagrant ansible_user=ubuntu
+
 [vagrant:children]
 bastion
 zuul
 nodepool
 mysql
 log
+monitor

--- a/inventory/vagrant
+++ b/inventory/vagrant
@@ -10,16 +10,14 @@ zuul.vagrant ansible_user=ubuntu
 [mysql]
 zuul.vagrant ansible_user=ubuntu
 
+[zookeeper]
+nodepool.vagrant ansible_user=ubuntu
+
 [log]
 logs.vagrant ansible_user=ubuntu
-
-[monitor]
-monitor.vagrant ansible_user=ubuntu
 
 [vagrant:children]
 bastion
 zuul
 nodepool
-mysql
 log
-monitor

--- a/roles/filebeat/README.md
+++ b/roles/filebeat/README.md
@@ -1,0 +1,70 @@
+# Ansible Role: Filebeat for ELK Stack
+
+[![Build Status](https://travis-ci.org/geerlingguy/ansible-role-filebeat.svg?branch=master)](https://travis-ci.org/geerlingguy/ansible-role-filebeat)
+
+An Ansible Role that installs [Filebeat](https://www.elastic.co/products/beats/filebeat) on RedHat/CentOS or Debian/Ubuntu.
+
+## Requirements
+
+None.
+
+## Role Variables
+
+Available variables are listed below, along with default values (see `defaults/main.yml`):
+
+    filebeat_prospectors:
+      - input_type: log
+        paths:
+          - "/var/log/*.log"
+
+Prospectors that will be listed in the `prospectors` section of the Filebeat configuration. Read through the [Filebeat Prospectors configuration guide](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-filebeat-options.html) for more options.
+
+    filebeat_output_elasticsearch_enabled: false
+    filebeat_output_elasticsearch_hosts:
+      - "localhost:9200"
+
+Whether to enable Elasticsearch output, and which hosts to send output to.
+
+    filebeat_output_logstash_enabled: true
+    filebeat_output_logstash_hosts:
+      - "localhost:5000"
+
+Whether to enable Logstash output, and which hosts to send output to.
+
+    filebeat_ssl_dir: /etc/pki/logstash
+
+The path where certificates and keyfiles will be stored.
+
+    filebeat_ssl_certificate_file: ""
+    filebeat_ssl_key_file: ""
+
+Local paths to the SSL certificate and key files, which will be copied into the `filebeat_ssl_dir`.
+
+For utmost security, you should use your own valid certificate and keyfile, and update the `filebeat_ssl_*` variables in your playbook to use your certificate.
+
+To generate a self-signed certificate/key pair, you can use use the command:
+
+    $ sudo openssl req -x509 -batch -nodes -days 3650 -newkey rsa:2048 -keyout filebeat.key -out filebeat.crt
+
+Note that filebeat and logstash may not work correctly with self-signed certificates unless you also have the full chain of trust (including the Certificate Authority for your self-signed cert) added on your server. See: https://github.com/elastic/logstash/issues/4926#issuecomment-203936891
+
+## Dependencies
+
+None.
+
+## Example Playbook
+
+    - hosts: logs
+      roles:
+        - geerlingguy.java
+        - geerlingguy.elasticsearch
+        - geerlingguy.logstash
+        - geerlingguy.filebeat
+
+## License
+
+MIT / BSD
+
+## Author Information
+
+This role was created in 2016 by [Jeff Geerling](https://www.jeffgeerling.com/), author of [Ansible for DevOps](https://www.ansiblefordevops.com/).

--- a/roles/filebeat/defaults/main.yml
+++ b/roles/filebeat/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+filebeat_prospectors:
+  - input_type: log
+    paths:
+      - "/var/log/*.log"
+
+filebeat_output_elasticsearch_enabled: false
+filebeat_output_elasticsearch_hosts:
+  - "localhost:9200"
+
+filebeat_output_logstash_enabled: true
+filebeat_output_logstash_hosts:
+  - "localhost:5044"
+
+filebeat_ssl_dir: /etc/pki/logstash
+filebeat_ssl_certificate_file: ""
+filebeat_ssl_key_file: ""

--- a/roles/filebeat/handlers/main.yml
+++ b/roles/filebeat/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart filebeat
+  service: name=filebeat state=restarted

--- a/roles/filebeat/meta/main.yml
+++ b/roles/filebeat/meta/main.yml
@@ -1,0 +1,26 @@
+---
+dependencies: []
+
+galaxy_info:
+  author: geerlingguy
+  description: Filebeat for Linux.
+  company: "Midwestern Mac, LLC"
+  license: "license (BSD, MIT)"
+  min_ansible_version: 2.0
+  platforms:
+  - name: EL
+    versions:
+    - 6
+    - 7
+  - name: Debian
+    versions:
+    - jessie
+  - name: Ubuntu
+    versions:
+    - precise
+    - trusty
+    - xenial
+  galaxy_tags:
+    - web
+    - system
+    - monitoring

--- a/roles/filebeat/tasks/config.yml
+++ b/roles/filebeat/tasks/config.yml
@@ -1,0 +1,26 @@
+---
+- name: Copy Filebeat configuration.
+  template:
+    src: filebeat.yml.j2
+    dest: "/etc/filebeat/filebeat.yml"
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart filebeat
+
+- name: Ensure Filebeat SSL key pair directory exists.
+  file:
+    path: "{{ filebeat_ssl_dir }}"
+    state: directory
+  when: filebeat_ssl_key_file
+
+- name: Copy SSL key and cert for filebeat.
+  copy:
+    src: "{{ item }}"
+    dest: "{{ filebeat_ssl_dir }}/{{ item | basename }}"
+    mode: 0644
+  with_items:
+    - "{{ filebeat_ssl_key_file }}"
+    - "{{ filebeat_ssl_certificate_file }}"
+  notify: restart filebeat
+  when: filebeat_ssl_key_file and filebeat_ssl_certificate_file

--- a/roles/filebeat/tasks/main.yml
+++ b/roles/filebeat/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- include: setup-RedHat.yml
+  when: ansible_os_family == 'RedHat'
+
+- include: setup-Debian.yml
+  when: ansible_os_family == 'Debian'
+
+- name: Install Filebeat.
+  package: name=filebeat state=present
+
+- include: config.yml
+
+- name: Ensure Filebeat is started and enabled at boot.
+  service:
+    name: filebeat
+    state: started
+    enabled: yes

--- a/roles/filebeat/tasks/setup-Debian.yml
+++ b/roles/filebeat/tasks/setup-Debian.yml
@@ -1,0 +1,14 @@
+---
+- name: Ensure depdency is installed (Ubuntu).
+  apt: name=apt-transport-https state=present
+
+- name: Add Elasticsearch apt key.
+  apt_key:
+    url: https://packages.elastic.co/GPG-KEY-elasticsearch
+    state: present
+
+- name: Add Filebeat repository.
+  apt_repository:
+    repo: 'deb https://packages.elastic.co/beats/apt stable main'
+    state: present
+    update_cache: yes

--- a/roles/filebeat/tasks/setup-RedHat.yml
+++ b/roles/filebeat/tasks/setup-RedHat.yml
@@ -1,0 +1,11 @@
+---
+- name: Add Elasticsearch GPG key.
+  rpm_key:
+    key: https://packages.elastic.co/GPG-KEY-elasticsearch
+    state: present
+
+- name: Add Filebeat repository.
+  template:
+    src: beats.repo.j2
+    dest: /etc/yum.repos.d/beats.repo
+    mode: 0644

--- a/roles/filebeat/templates/beats.repo.j2
+++ b/roles/filebeat/templates/beats.repo.j2
@@ -1,0 +1,6 @@
+[beats]
+name=Elastic Beats Repository
+baseurl=https://packages.elastic.co/beats/yum/el/$basearch
+enabled=1
+gpgkey=https://packages.elastic.co/GPG-KEY-elasticsearch
+gpgcheck=1

--- a/roles/filebeat/templates/filebeat.yml.j2
+++ b/roles/filebeat/templates/filebeat.yml.j2
@@ -1,0 +1,132 @@
+filebeat:
+  # List of prospectors to fetch data.
+  prospectors:
+    {{ filebeat_prospectors | to_json }}
+
+# Configure what outputs to use when sending the data collected by the beat.
+# Multiple outputs may be used.
+output:
+
+{% if filebeat_output_elasticsearch_enabled %}
+  ### Elasticsearch as output
+  elasticsearch:
+    # Array of hosts to connect to.
+    hosts: {{ filebeat_output_elasticsearch_hosts | to_json }}
+
+    # Optional protocol and basic auth credentials. These are deprecated.
+    #protocol: "https"
+    #username: "admin"
+    #password: "s3cr3t"
+
+    # Number of workers per Elasticsearch host.
+    #worker: 1
+
+    # Optional index name. The default is "filebeat" and generates
+    # [filebeat-]YYYY.MM.DD keys.
+    #index: "filebeat"
+
+    # Optional HTTP Path
+    #path: "/elasticsearch"
+
+    # Proxy server URL
+    # proxy_url: http://proxy:3128
+
+    # The number of times a particular Elasticsearch index operation is attempted. If
+    # the indexing operation doesn't succeed after this many retries, the events are
+    # dropped. The default is 3.
+    #max_retries: 3
+
+    # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
+    # The default is 50.
+    #bulk_max_size: 50
+
+    # Configure http request timeout before failing an request to Elasticsearch.
+    #timeout: 90
+
+    # The number of seconds to wait for new events between two bulk API index requests.
+    # If `bulk_max_size` is reached before this interval expires, addition bulk index
+    # requests are made.
+    #flush_interval: 1
+
+    # Boolean that sets if the topology is kept in Elasticsearch. The default is
+    # false. This option makes sense only for Packetbeat.
+    #save_topology: false
+
+    # The time to live in seconds for the topology information that is stored in
+    # Elasticsearch. The default is 15 seconds.
+    #topology_expire: 15
+
+{% if filebeat_ssl_certificate_file and filebeat_ssl_key_file %}
+    # tls configuration. By default is off.
+    tls:
+      # List of root certificates for HTTPS server verifications
+      #certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+      # Certificate for TLS client authentication
+      certificate: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_certificate_file | basename }}"
+
+      # Client Certificate Key
+      certificate_key: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_key_file | basename}}"
+
+      # Controls whether the client verifies server certificates and host name.
+      # If insecure is set to true, all server host names and certificates will be
+      # accepted. In this mode TLS based connections are susceptible to
+      # man-in-the-middle attacks. Use only for testing.
+      #insecure: true
+
+      # Configure cipher suites to be used for TLS connections
+      #cipher_suites: []
+
+      # Configure curve types for ECDHE based cipher suites
+      #curve_types: []
+
+      # Configure minimum TLS version allowed for connection to logstash
+      #min_version: 1.0
+
+      # Configure maximum TLS version allowed for connection to logstash
+      #max_version: 1.2
+{% endif %}
+{% endif %}
+
+{% if filebeat_output_logstash_enabled %}
+  ### Logstash as output
+  logstash:
+    # The Logstash hosts
+    hosts: {{ filebeat_output_logstash_hosts | to_json }}
+
+    # Number of workers per Logstash host.
+    #worker: 1
+
+    # Optional load balance the events between the Logstash hosts
+    #loadbalance: true
+
+    # Optional index name. The default index name depends on the each beat.
+    # For Packetbeat, the default is set to packetbeat, for Topbeat
+    # top topbeat and for Filebeat to filebeat.
+    #index: filebeat
+
+{% if filebeat_ssl_certificate_file and filebeat_ssl_key_file %}
+    # Optional TLS. By default is off.
+    tls:
+      # List of root certificates for HTTPS server verifications
+      #certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+      # Certificate for TLS client authentication
+      certificate: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_certificate_file | basename }}"
+
+      # Client Certificate Key
+      certificate_key: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_key_file | basename}}"
+
+      # Controls whether the client verifies server certificates and host name.
+      # If insecure is set to true, all server host names and certificates will be
+      # accepted. In this mode TLS based connections are susceptible to
+      # man-in-the-middle attacks. Use only for testing.
+      #insecure: true
+
+      # Configure cipher suites to be used for TLS connections
+      #cipher_suites: []
+
+      # Configure curve types for ECDHE based cipher suites
+      #curve_types: []
+{% endif %}
+{% endif %}

--- a/roles/filebeat/tests/requirements.yml
+++ b/roles/filebeat/tests/requirements.yml
@@ -1,0 +1,4 @@
+---
+- src: geerlingguy.java
+- src: geerlingguy.elasticsearch
+- src: geerlingguy.logstash

--- a/roles/filebeat/tests/test.yml
+++ b/roles/filebeat/tests/test.yml
@@ -1,0 +1,20 @@
+---
+- hosts: all
+
+  pre_tasks:
+    - name: Update apt cache.
+      apt: update_cache=yes cache_valid_time=600
+      when: ansible_os_family == 'Debian'
+
+    - name: Install test dependencies (RedHat).
+      package: name=which state=present
+      when: ansible_os_family == 'RedHat'
+
+    - name: Install test dependencies.
+      package: name=curl state=present
+
+  roles:
+    - geerlingguy.java
+    - geerlingguy.elasticsearch
+    - geerlingguy.logstash
+    - role_under_test

--- a/roles/java/README.md
+++ b/roles/java/README.md
@@ -1,0 +1,66 @@
+# Ansible Role: Java
+
+[![Build Status](https://travis-ci.org/geerlingguy/ansible-role-java.svg?branch=master)](https://travis-ci.org/geerlingguy/ansible-role-java)
+
+Installs Java for RedHat/CentOS and Debian/Ubuntu linux servers.
+
+## Requirements
+
+None.
+
+## Role Variables
+
+Available variables are listed below, along with default values:
+
+    # The defaults provided by this role are specific to each distribution.
+    java_packages:
+      - java-1.7.0-openjdk
+
+Set the version/development kit of Java to install, along with any other necessary Java packages. Some other options include are included in the distribution-specific files in this role's 'defaults' folder.
+
+    java_home: ""
+
+If set, the role will set the global environment variable `JAVA_HOME` to this value.
+
+## Dependencies
+
+None.
+
+## Example Playbook (using default package, usually OpenJDK 7)
+
+    - hosts: servers
+      roles:
+        - geerlingguy.java
+
+## Example Playbook (install OpenJDK 8)
+
+For RHEL / CentOS:
+
+    - hosts: server
+      roles:
+        - role: geerlingguy.java
+          when: "ansible_os_family == 'RedHat'"
+          java_packages:
+            - java-1.8.0-openjdk
+
+For Ubuntu < 16.04:
+
+    - hosts: server
+      tasks:
+        - name: installing repo for Java 8 in Ubuntu
+  	      apt_repository: repo='ppa:openjdk-r/ppa'
+    
+    - hosts: server
+      roles:
+        - role: geerlingguy.java
+          when: "ansible_os_family == 'Debian'"
+          java_packages:
+            - openjdk-8-jdk
+
+## License
+
+MIT / BSD
+
+## Author Information
+
+This role was created in 2014 by [Jeff Geerling](https://www.jeffgeerling.com/), author of [Ansible for DevOps](https://www.ansiblefordevops.com/).

--- a/roles/java/defaults/main.yml
+++ b/roles/java/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# Set java_packages if you would like to use a different version than the
+# default (OpenJDK 1.7).
+# java_packages: []
+
+java_home: ""

--- a/roles/java/meta/main.yml
+++ b/roles/java/meta/main.yml
@@ -1,0 +1,30 @@
+---
+dependencies: []
+
+galaxy_info:
+  author: geerlingguy
+  description: Java for Linux
+  company: "Midwestern Mac, LLC"
+  license: "license (BSD, MIT)"
+  min_ansible_version: 2.0
+  platforms:
+    - name: EL
+      versions:
+      - 6
+      - 7
+    - name: Fedora
+      versions:
+      - all
+    - name: Debian
+      versions:
+      - all
+    - name: Ubuntu
+      versions:
+      - all
+    - name: FreeBSD
+      versions:
+      - 10.2
+  galaxy_tags:
+    - development
+    - system
+    - web

--- a/roles/java/tasks/main.yml
+++ b/roles/java/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+- name: Include OS-specific variables.
+  include_vars: "{{ ansible_os_family }}.yml"
+  when: ansible_distribution != 'Ubuntu' or ansible_distribution != 'Fedora'
+
+- name: Include OS-specific variables for Fedora.
+  include_vars: "{{ ansible_distribution }}.yml"
+  when: ansible_distribution == 'Fedora'
+
+- name: Include version-specific variables for Ubuntu.
+  include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml"
+  when: ansible_distribution == 'Ubuntu'
+
+- name: Define java_packages.
+  set_fact:
+    java_packages: "{{ __java_packages | list }}"
+  when: java_packages is not defined
+
+# Setup/install tasks.
+- include: setup-RedHat.yml
+  when: ansible_os_family == 'RedHat'
+  static: no
+
+- include: setup-Debian.yml
+  when: ansible_os_family == 'Debian'
+  static: no
+
+- include: setup-FreeBSD.yml
+  when: ansible_os_family == 'FreeBSD'
+  static: no
+
+# Environment setup.
+- name: Set JAVA_HOME if configured.
+  template:
+    src: java_home.sh.j2
+    dest: /etc/profile.d/java_home.sh
+    mode: 0644
+  when: java_home

--- a/roles/java/tasks/setup-Debian.yml
+++ b/roles/java/tasks/setup-Debian.yml
@@ -1,0 +1,7 @@
+---
+- name: Update apt cache.
+  apt: update_cache=yes cache_valid_time=600
+
+- name: Ensure Java is installed.
+  apt: "name={{ item }} state=present"
+  with_items: "{{ java_packages }}"

--- a/roles/java/tasks/setup-FreeBSD.yml
+++ b/roles/java/tasks/setup-FreeBSD.yml
@@ -1,0 +1,10 @@
+---
+- name: Ensure Java is installed.
+  pkgng: "name={{ item }} state=present"
+  with_items: "{{ java_packages }}"
+
+- name: ensure proc is mounted
+  mount: name=/proc fstype=procfs src=proc opts=rw state=mounted
+
+- name: ensure fdesc is mounted
+  mount: name=/dev/fd fstype=fdescfs src=fdesc opts=rw state=mounted

--- a/roles/java/tasks/setup-RedHat.yml
+++ b/roles/java/tasks/setup-RedHat.yml
@@ -1,0 +1,4 @@
+---
+- name: Ensure Java is installed.
+  package: "name={{ item }} state=installed"
+  with_items: "{{ java_packages }}"

--- a/roles/java/templates/java_home.sh.j2
+++ b/roles/java/templates/java_home.sh.j2
@@ -1,0 +1,1 @@
+export JAVA_HOME={{ java_home }}

--- a/roles/java/tests/test.yml
+++ b/roles/java/tests/test.yml
@@ -1,0 +1,11 @@
+---
+- hosts: all
+
+  pre_tasks:
+    - name: Update apt cache.
+      apt: update_cache=yes cache_valid_time=600
+      when: ansible_os_family == 'Debian'
+      changed_when: false
+
+  roles:
+    - role_under_test

--- a/roles/java/vars/Debian.yml
+++ b/roles/java/vars/Debian.yml
@@ -1,0 +1,7 @@
+---
+# JDK version options include:
+#   - java
+#   - openjdk-6-jdk
+#   - openjdk-7-jdk
+__java_packages:
+  - openjdk-7-jdk

--- a/roles/java/vars/Fedora.yml
+++ b/roles/java/vars/Fedora.yml
@@ -1,0 +1,6 @@
+---
+# JDK version options include:
+#   - java
+#   - java-1.8.0-openjdk
+__java_packages:
+  - java-1.8.0-openjdk

--- a/roles/java/vars/FreeBSD.yml
+++ b/roles/java/vars/FreeBSD.yml
@@ -1,0 +1,7 @@
+---
+# JDK version options for FreeBSD include:
+#   - openjdk
+#   - openjdk6
+#   - openjdk8
+__java_packages:
+  - openjdk

--- a/roles/java/vars/RedHat.yml
+++ b/roles/java/vars/RedHat.yml
@@ -1,0 +1,7 @@
+---
+# JDK version options include:
+#   - java
+#   - java-1.6.0-openjdk
+#   - java-1.7.0-openjdk
+__java_packages:
+  - java-1.7.0-openjdk

--- a/roles/java/vars/Ubuntu-12.04.yml
+++ b/roles/java/vars/Ubuntu-12.04.yml
@@ -1,0 +1,7 @@
+---
+# JDK version options include:
+#   - java
+#   - openjdk-6-jdk
+#   - openjdk-7-jdk
+__java_packages:
+  - openjdk-7-jdk

--- a/roles/java/vars/Ubuntu-14.04.yml
+++ b/roles/java/vars/Ubuntu-14.04.yml
@@ -1,0 +1,7 @@
+---
+# JDK version options include:
+#   - java
+#   - openjdk-6-jdk
+#   - openjdk-7-jdk
+__java_packages:
+  - openjdk-7-jdk

--- a/roles/java/vars/Ubuntu-16.04.yml
+++ b/roles/java/vars/Ubuntu-16.04.yml
@@ -1,0 +1,7 @@
+---
+# JDK version options include:
+#   - java
+#   - openjdk-8-jdk
+#   - openjdk-9-jdk
+__java_packages:
+  - openjdk-8-jdk

--- a/roles/logstash/README.md
+++ b/roles/logstash/README.md
@@ -1,0 +1,77 @@
+# Ansible Role: Logstash
+
+[![Build Status](https://travis-ci.org/geerlingguy/ansible-role-logstash.svg?branch=master)](https://travis-ci.org/geerlingguy/ansible-role-logstash)
+
+An Ansible Role that installs Logstash on RedHat/CentOS Debian/Ubuntu.
+
+Note that this role installs a syslog grok pattern by default; if you want to add more filters, please add them inside the `/etc/logstash/conf.d/` directory. As an example, you could create a file named `13-myapp.conf` with the appropriate grok filter and restart logstash to start using it. Test your grok regex using the [Grok Debugger](http://grokdebug.herokuapp.com/).
+
+## Requirements
+
+Though other methods are possible, this role is made to work with Elasticsearch as a backend for storing log messages.
+
+## Role Variables
+
+Available variables are listed below, along with default values (see `defaults/main.yml`):
+
+    logstash_listen_port_beats: 5044
+
+The port over which Logstash will listen for beats.
+
+    logstash_outputs:
+      elasticsearch:
+        hosts: [ "http://localhost:9200" ]
+        index: "%{[@metadata][beat]}-%{+YYYY.MM.dd}"
+        document_type: "%{[@metadata][type]}"
+
+The default output which sends logs to a local Elasticsearch node.
+
+    logstash_ssl_dir: /etc/pki/logstash
+    logstash_ssl_certificate_file: logstash-forwarder-example.crt
+    logstash_ssl_key_file: logstash-forwarder-example.key
+
+Local paths to the SSL certificate and key files, which will be copied into the `logstash_ssl_dir`.
+
+For utmost security, you should use your own valid certificate and keyfile, and update the `logstash_ssl_*` variables in your playbook to use your certificate.
+
+To generate a self-signed certificate/key pair, you can use use the command:
+
+    $ sudo openssl req -x509 -batch -nodes -days 3650 -newkey rsa:2048 -keyout logstash.key -out logstash.crt
+
+Note that filebeat and logstash may not work correctly with self-signed certificates unless you also have the full chain of trust (including the Certificate Authority for your self-signed cert) added on your server. See: https://github.com/elastic/logstash/issues/4926#issuecomment-203936891
+
+    logstash_local_syslog_path: /var/log/syslog
+    logstash_monitor_local_syslog: true
+
+Whether configuration for local syslog file (defined as `logstash_local_syslog_path`) should be added to logstash. Set this to `false` if you are monitoring the local syslog differently, or if you don't care about the local syslog file. Other local logs can be added by your own configuration files placed inside `/etc/logstash/conf.d`.
+
+    logstash_enabled_on_boot: yes
+
+Set this to `no` if you don't want logstash to run on system startup.
+
+    logstash_install_plugins:
+      - logstash-input-beats
+
+A list of Logstash plugins that should be installed.
+
+## Other Notes
+
+If you are seeing high CPU usage from one of the `logstash` processes, and you're using Logstash along with another application running on port 80 on a platform like Ubuntu with upstart, the `logstash-web` process may be stuck in a loop trying to start on port 80, failing, and trying to start again, due to the `restart` flag being present in `/etc/init/logstash-web.conf`. To avoid this problem, either change that line to add a `limit` to the respawn statement, or set the `logstash-web` service to `enabled=no` in your playbook, e.g.:
+
+    - name: Ensure logstash-web process is stopped and disabled.
+      service: name=logstash-web state=stopped enabled=no
+
+## Example Playbook
+
+    - hosts: search
+      roles:
+        - geerlingguy.elasticsearch
+        - geerlingguy.logstash
+
+## License
+
+MIT / BSD
+
+## Author Information
+
+This role was created in 2014 by [Jeff Geerling](http://www.jeffgeerling.com/), author of [Ansible for DevOps](https://www.ansiblefordevops.com/).

--- a/roles/logstash/defaults/main.yml
+++ b/roles/logstash/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+logstash_listen_port_beats: 5044
+
+logstash_outputs:
+  elasticsearch:
+    hosts: [ "http://localhost:9200" ]
+    index: "%{[@metadata][beat]}-%{+YYYY.MM.dd}"
+    document_type: "%{[@metadata][type]}"
+
+logstash_local_syslog_path: /var/log/syslog
+logstash_monitor_local_syslog: true
+
+logstash_ssl_dir: /etc/pki/logstash
+logstash_ssl_certificate_file: ""
+logstash_ssl_key_file: ""
+
+logstash_enabled_on_boot: yes
+
+logstash_install_plugins:
+  - logstash-input-beats

--- a/roles/logstash/files/filters/10-syslog.conf
+++ b/roles/logstash/files/filters/10-syslog.conf
@@ -1,0 +1,16 @@
+filter {
+  if [type] == "syslog" {
+    if [message] =~ /last message repeated [0-9]+ times/ {
+      drop { }
+    }
+    grok {
+      match => { "message" => "%{SYSLOGTIMESTAMP:syslog_timestamp} %{SYSLOGHOST:syslog_hostname} %{DATA:syslog_program}(?:\[%{POSINT:syslog_pid}\])?: %{GREEDYDATA:syslog_message}" }
+      add_field => [ "received_at", "%{@timestamp}" ]
+      add_field => [ "received_from", "%{host}" ]
+    }
+    syslog_pri { }
+    date {
+      match => [ "syslog_timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss" ]
+    }
+  }
+}

--- a/roles/logstash/files/filters/11-nginx.conf
+++ b/roles/logstash/files/filters/11-nginx.conf
@@ -1,0 +1,7 @@
+filter {
+  if [type] == "nginx" {
+    grok {
+      match => { "message" => "%{COMBINEDAPACHELOG}" }
+    }
+  }
+}

--- a/roles/logstash/files/filters/12-apache.conf
+++ b/roles/logstash/files/filters/12-apache.conf
@@ -1,0 +1,10 @@
+filter {
+  if [type] == "apache" {
+      grok {
+        match => { "message" => "%{COMBINEDAPACHELOG}"}
+      }
+      date {
+        match => [ "timestamp", "dd/MMM/yyyy:HH:mm:ss Z" ]
+      }
+  }
+}

--- a/roles/logstash/files/filters/14-solr.conf
+++ b/roles/logstash/files/filters/14-solr.conf
@@ -1,0 +1,15 @@
+filter {
+  if [type] == "solr" {
+    if [message] =~ /org\.apache\.solr\.core\.SolrCore execute/ {
+      drop { }
+    }
+    grok {
+      match => { "message" => "<%{POSINT:priority}>%{SYSLOGLINE}"}
+    }
+    multiline {
+      pattern => "(([^\s]+)Exception.+)|(at:.+)"
+      stream_identity => "%{logsource}.%{@type}"
+      what => "previous"
+    }
+  }
+}

--- a/roles/logstash/files/filters/15-drupal.conf
+++ b/roles/logstash/files/filters/15-drupal.conf
@@ -1,0 +1,7 @@
+filter {
+  if [type] == "drupal" {
+    grok {
+      match => ["message", "%{SYSLOGTIMESTAMP} %{HOSTNAME} %{WORD}: %{URI:drupal_vhost}\|%{NUMBER:drupal_timestamp}\|(?<drupal_action>[^\|]*)\|%{IP:drupal_ip}\|(?<drupal_request_uri>[^\|]*)\|(?<drupal_referer>[^\|]*)\|(?<drupal_uid>[^\|]*)\|(?<drupal_link>[^\|]*)\|%{GREEDYDATA:drupal_message}" ]
+    }
+  }
+}

--- a/roles/logstash/files/logstash.repo
+++ b/roles/logstash/files/logstash.repo
@@ -1,0 +1,6 @@
+[logstash-2.3]
+name=Logstash repository for 2.3.x packages
+baseurl=http://packages.elastic.co/logstash/2.3/centos
+gpgcheck=1
+gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
+enabled=1

--- a/roles/logstash/filter_plugins/logstash.py
+++ b/roles/logstash/filter_plugins/logstash.py
@@ -1,0 +1,26 @@
+def to_logstash(arg, indent=4, oneline=False):
+  if isinstance(arg, dict):
+    lines = []
+    for k,v in arg.iteritems():
+      if isinstance(v, dict):
+        fragment = '%s => { %s }' % (k, to_logstash(v, oneline=True))
+      else:
+        fragment = '%s => %s' % (k, to_logstash(v, oneline=True))
+      lines.append(fragment)
+
+    if oneline:
+      prefix = ' '
+    else:
+      prefix = '\n' + (' ' * indent)
+    out = prefix.join(lines)
+  elif hasattr(arg, '__iter__'):
+    out = '[ %s ]' % ', '.join([ to_logstash(i, oneline=True) for i in arg])
+  else:
+    out = arg
+
+  return out
+
+
+class FilterModule(object):
+  def filters(self):
+    return {'to_logstash': to_logstash}

--- a/roles/logstash/handlers/main.yml
+++ b/roles/logstash/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart logstash
+  service: name=logstash state=restarted

--- a/roles/logstash/meta/main.yml
+++ b/roles/logstash/meta/main.yml
@@ -1,0 +1,24 @@
+---
+dependencies: []
+
+galaxy_info:
+  author: geerlingguy
+  description: Logstash for Linux.
+  company: "Midwestern Mac, LLC"
+  license: "license (BSD, MIT)"
+  min_ansible_version: 1.8
+  platforms:
+    - name: EL
+      versions:
+      - 6
+      - 7
+    - name: Debian
+      versions:
+      - all
+    - name: Ubuntu
+      versions:
+      - all
+  galaxy_tags:
+    - web
+    - system
+    - monitoring

--- a/roles/logstash/tasks/config.yml
+++ b/roles/logstash/tasks/config.yml
@@ -1,0 +1,44 @@
+---
+- name: Create Logstash configuration files.
+  template:
+    src: "{{ item }}.j2"
+    dest: "/etc/logstash/conf.d/{{ item }}"
+    owner: root
+    group: root
+    mode: 0644
+  with_items:
+    - 01-beats-input.conf
+    - 30-output.conf
+  notify: restart logstash
+
+- name: Create Logstash filters.
+  copy:
+    src: "filters/{{ item }}"
+    dest: "/etc/logstash/conf.d/{{ item }}"
+    owner: root
+    group: root
+    mode: 0644
+  with_items:
+    - 10-syslog.conf
+    - 11-nginx.conf
+    - 12-apache.conf
+    - 14-solr.conf
+    - 15-drupal.conf
+  notify: restart logstash
+
+- name: Create Logstash configuration file for local syslog.
+  template:
+    src: 02-local-syslog-input.conf.j2
+    dest: /etc/logstash/conf.d/02-local-syslog-input.conf
+    owner: root
+    group: root
+    mode: 0644
+  when: logstash_monitor_local_syslog
+  notify: restart logstash
+
+- name: Ensure configuration for local syslog is absent if disabled.
+  file:
+    path: /etc/logstash/conf.d/02-local-syslog-input.conf
+    state: absent
+  when: not logstash_monitor_local_syslog
+  notify: restart logstash

--- a/roles/logstash/tasks/main.yml
+++ b/roles/logstash/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- include: setup-RedHat.yml
+  when: ansible_os_family == 'RedHat'
+
+- include: setup-Debian.yml
+  when: ansible_os_family == 'Debian'
+
+- include: config.yml
+- include: ssl.yml
+- include: plugins.yml
+
+- name: Ensure Logstash is started and enabled on boot.
+  service: "name=logstash state=started enabled={{ logstash_enabled_on_boot }}"

--- a/roles/logstash/tasks/plugins.yml
+++ b/roles/logstash/tasks/plugins.yml
@@ -1,0 +1,15 @@
+---
+- name: Get list of installed plugins.
+  command: >
+    ./bin/logstash-plugin list
+    chdir=/opt/logstash
+  register: logstash_plugins_list
+  changed_when: false
+
+- name: Install configured plugins.
+  command: >
+    ./bin/logstash-plugin install {{ item }}
+    chdir=/opt/logstash
+  with_items: "{{ logstash_install_plugins }}"
+  when: "item not in logstash_plugins_list.stdout"
+  notify: restart logstash

--- a/roles/logstash/tasks/setup-Debian.yml
+++ b/roles/logstash/tasks/setup-Debian.yml
@@ -1,0 +1,29 @@
+---
+- name: Add Elasticsearch apt key.
+  apt_key:
+    url: http://packages.elasticsearch.org/GPG-KEY-elasticsearch
+    state: present
+
+- name: Add Logstash repository.
+  apt_repository:
+    repo: 'deb http://packages.elasticsearch.org/logstash/2.3/debian stable main'
+    state: present
+
+- name: Check if Logstash is already installed.
+  stat: path=/etc/init.d/logstash
+  register: logstash_installed
+
+- name: Update apt cache if repository just added.
+  apt: update_cache=yes
+  when: logstash_installed.stat.exists == false
+
+- name: Install Logstash.
+  apt: pkg=logstash state=present
+
+- name: Add Logstash user to adm group (Debian).
+  user:
+    name: logstash
+    group: logstash
+    groups: adm
+  when: ansible_os_family == "Debian"
+  notify: restart logstash

--- a/roles/logstash/tasks/setup-RedHat.yml
+++ b/roles/logstash/tasks/setup-RedHat.yml
@@ -1,0 +1,14 @@
+---
+- name: Add Elasticsearch GPG key.
+  rpm_key:
+    key: http://packages.elasticsearch.org/GPG-KEY-elasticsearch
+    state: present
+
+- name: Add Logstash repository.
+  copy:
+    src: logstash.repo
+    dest: /etc/yum.repos.d/logstash.repo
+    mode: 0644
+
+- name: Install Logstash.
+  yum: pkg=logstash state=installed

--- a/roles/logstash/tasks/ssl.yml
+++ b/roles/logstash/tasks/ssl.yml
@@ -1,0 +1,17 @@
+---
+- name: Ensure Logstash SSL key pair directory exists.
+  file:
+    path: "{{ logstash_ssl_dir }}"
+    state: directory
+  when: logstash_ssl_key_file
+
+- name: Copy SSL key and cert for logstash-forwarder.
+  copy:
+    src: "{{ item }}"
+    dest: "{{ logstash_ssl_dir }}/{{ item | basename }}"
+    mode: 0644
+  with_items:
+    - "{{ logstash_ssl_key_file }}"
+    - "{{ logstash_ssl_certificate_file }}"
+  notify: restart logstash
+  when: logstash_ssl_key_file

--- a/roles/logstash/templates/01-beats-input.conf.j2
+++ b/roles/logstash/templates/01-beats-input.conf.j2
@@ -1,0 +1,11 @@
+input {
+  beats {
+    port => {{ logstash_listen_port_beats }}
+{% if logstash_ssl_certificate_file and logstash_ssl_key_file %}
+    ssl => true
+    ssl_certificate => "{{ logstash_ssl_dir }}/{{ logstash_ssl_certificate_file | basename }}"
+    ssl_key => "{{ logstash_ssl_dir }}/{{ logstash_ssl_key_file | basename }}"
+    ssl_verify_mode => "force_peer"
+{% endif %}
+  }
+}

--- a/roles/logstash/templates/02-local-syslog-input.conf.j2
+++ b/roles/logstash/templates/02-local-syslog-input.conf.j2
@@ -1,0 +1,5 @@
+input {
+  file {
+    path => "{{ logstash_local_syslog_path }}"
+  }
+}

--- a/roles/logstash/templates/30-output.conf.j2
+++ b/roles/logstash/templates/30-output.conf.j2
@@ -1,0 +1,18 @@
+output {
+{% if logstash_elasticsearch_hosts is defined %}
+{# deprecated #}
+# The ansible variable 'logstash_elasticsearch_hosts' is deprecated.
+# Please consider switching to the more generic 'logstash_outputs' variable.
+  elasticsearch {
+    hosts => {{ logstash_elasticsearch_hosts | to_json }}
+    index => "%{[@metadata][beat]}-%{+YYYY.MM.dd}"
+    document_type => "%{[@metadata][type]}"
+  }
+{% else %}
+{% for name, params in logstash_outputs.iteritems() %}
+  {{ name }} {
+    {{ params | to_logstash }}
+  }
+{% endfor %}
+{% endif %}
+}

--- a/roles/logstash/tests/requirements.yml
+++ b/roles/logstash/tests/requirements.yml
@@ -1,0 +1,3 @@
+---
+- src: geerlingguy.java
+- src: geerlingguy.elasticsearch

--- a/roles/logstash/tests/test.yml
+++ b/roles/logstash/tests/test.yml
@@ -1,0 +1,15 @@
+---
+- hosts: all
+
+  vars:
+    logstash_enabled_on_boot: no
+
+  pre_tasks:
+    - name: Update apt cache.
+      apt: update_cache=yes cache_valid_time=600
+      when: ansible_os_family == 'Debian'
+
+  roles:
+    - geerlingguy.java
+    - geerlingguy.elasticsearch
+    - role_under_test

--- a/roles/monitor-system-logs/meta/main.yml
+++ b/roles/monitor-system-logs/meta/main.yml
@@ -1,0 +1,31 @@
+dependencies:
+  - role: java
+  - role: logstash
+    logstash_monitor_local_syslog: false
+    logstash_outputs:
+      file:
+        path: '"/var/www/html/logstash/%{host}/%{source}"'
+        codec: 'line { format => "%{message}" }'
+  - role: tailon
+    tailon_ip: 127.0.0.1
+    tailon_port: 8080
+    tailon_relative_root: /tailon/
+    tailon_files:
+      - "/var/www/html/logstash/nodepool/var/log/nodepool/*log"
+      - "/var/www/html/logstash/zuul/var/log/zuul/*log"
+  - role: apache
+    apache_mods_enabled:
+      - proxy.conf
+      - proxy.load
+      - proxy_http.load
+    apache_vhosts:
+      - name: tailon
+        document_root: /var/www/html/
+        document_root_options: +FollowSymLinks
+        vhost_extra: |
+          AddType text/plain .log
+          Redirect permanent /tailon /tailon/
+          ProxyPass "/tailon/" http://localhost:{{ tailon_port }}/tailon/
+  - role: dd-apache
+    tags:
+      - monitoring

--- a/roles/monitor-system-logs/meta/main.yml
+++ b/roles/monitor-system-logs/meta/main.yml
@@ -9,23 +9,10 @@ dependencies:
   - role: tailon
     tailon_ip: 127.0.0.1
     tailon_port: 8080
-    tailon_relative_root: /tailon/
+    tailon_relative_root: /system-logs/
     tailon_files:
       - "/var/www/html/logstash/nodepool/var/log/nodepool/*log"
       - "/var/www/html/logstash/zuul/var/log/zuul/*log"
-  - role: apache
-    apache_mods_enabled:
-      - proxy.conf
-      - proxy.load
-      - proxy_http.load
-    apache_vhosts:
-      - name: tailon
-        document_root: /var/www/html/
-        document_root_options: +FollowSymLinks
-        vhost_extra: |
-          AddType text/plain .log
-          Redirect permanent /tailon /tailon/
-          ProxyPass "/tailon/" http://localhost:{{ tailon_port }}/tailon/
   - role: dd-apache
     tags:
       - monitoring

--- a/roles/monitor-system-logs/tasks/main.yml
+++ b/roles/monitor-system-logs/tasks/main.yml
@@ -1,0 +1,5 @@
+- name: Create logstash output dir
+  file:
+    path: /var/www/html/logstash
+    state: directory
+    owner: logstash

--- a/roles/zuul/files/jobs/ansible.yaml
+++ b/roles/zuul/files/jobs/ansible.yaml
@@ -31,7 +31,7 @@
       - install-ansible
       - shell: |
           source /opt/venvs/ansible/bin/activate
-          ansible-playbook -i /dev/null --syntax-check $(find . tests -maxdepth 1 -type f -name \*.yml -not -name .travis.yml -not -name requirements.yml)
+          ansible-playbook -i /dev/null --syntax-check $(find . tests -maxdepth 1 -type f -name \*.yml -not -name .travis.yml)
 
     publishers:
       - console-log

--- a/roles/zuul/files/jobs/ansible.yaml
+++ b/roles/zuul/files/jobs/ansible.yaml
@@ -31,7 +31,7 @@
       - install-ansible
       - shell: |
           source /opt/venvs/ansible/bin/activate
-          ansible-playbook -i /dev/null --syntax-check $(find . tests -maxdepth 1 -type f -name \*.yml -not -name .travis.yml)
+          ansible-playbook -i /dev/null --syntax-check $(find . tests -maxdepth 1 -type f -name \*.yml -not -name .travis.yml -not -name requirements.yml)
 
     publishers:
       - console-log

--- a/tests/validate-ci.yml
+++ b/tests/validate-ci.yml
@@ -44,3 +44,27 @@
         - list
         - job-list
         - dib-image-list
+
+- name: Validate log server
+  hosts: log
+  tasks:
+    - name: logstash is running on filebeat port
+      become: yes
+      become_user: logstash
+      shell: lsof -nPi :5044 | grep LISTEN
+
+    - name: copy example console log
+      become: yes
+      copy:
+        src: logs/example.log
+        dest: "{{ bonnyci_logs_root_dir}}/console.log"
+        mode: "0444"
+
+- name: Validate logs are served
+  hosts: localhost
+  tasks:
+    - name: test logs are served
+      shell: curl --fail {{ bonnyci_logs_apache_server_name }}/console.log
+
+    - name: system logs served
+      shell: curl --fail {{ bonnyci_system_logs_apache_server_name }}/system-logs/


### PR DESCRIPTION
Create a monitor host, send nodepool and zuul logs there, and display them with
tailon.  Use Filebeat to ship the logs to a Logstash process on the new host.
The Logstash process then writes the logs to a file in a location where tailon
will find them. Using Filebeat and Logstash for this use-case makes it easier to
eventually expand to a full ELK cluster for system logs.

Implements BonnyCI/projman#33

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bonnyci/hoist/54)
<!-- Reviewable:end -->
