### PR TITLE
Add trigger to recheck gate

### DIFF
--- a/roles/zuul/templates/etc/zuul/config/layout.yaml
+++ b/roles/zuul/templates/etc/zuul/config/layout.yaml
@@ -37,6 +37,8 @@ pipelines:
       github:
         - event: pr-label
           label: 'approved'
+        - event: pr-comment
+          comment: (?i)gaterecheck
     start:
       github:
         comment: true


### PR DESCRIPTION
As read on https://github.com/BonnyCI/projman/wiki/GitHub-Pull-Request-Check-and-Gate-Design
This allows someone using Bonny to recheck their gate CI tests

Signed-off-by: Bradon Kanyid <bradon.kanyid@ibm.com>