### PR TITLE
Remove site.yml mention from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ sane.
 
 3. Run playbook::
 
-    $ ansible-playbook -i hosts -e @secrets.yml site.yml
+    $ ansible-playbook -i hosts -e @secrets.yml install-ci.yml
 
 Bastion
 =======


### PR DESCRIPTION
install-ci.yml takes the place of site.yml based on 82fa877. This will
remove the last reference to the outdated play name.

Signed-off-by: Cullen Taylor <CullenTaylor@outlook.com>