### PR TITLE
Fix signed-off-by-test.sh for best practices

### DIFF
--- a/tests/signed-off-by-test.sh
+++ b/tests/signed-off-by-test.sh
@@ -4,10 +4,9 @@ success="true"
 
 for commit in $(git cherry master | cut -d " " -f 2)
 do
-    git show -s $commit | grep -q 'Signed-off-by:'
-    if [ $? -ne 0 ]; then
+    if ! git show -s "$commit" | grep -q 'Signed-off-by:'; then
         echo "Commit $commit doesn't have a Signed-off-by"
-        git show $commit
+        git show "$commit"
         success="false"
     fi
 done


### PR DESCRIPTION
Script was updated in anticipation of `shellcheck` being added to CI
tests.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>