### PR TITLE
Add shellcheck to lint shell scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   - TEST_RUN="ansible-playbook -i inventory/allinone bastion.yml install-ci.yml tests/validate-ci.yml -c docker -vv -e @secrets.yml.example --skip-tags ddapi"
   - TEST_RUN="ansible-playbook -i inventory/allinone install-ci.yml tests/validate-ci.yml -c docker -vv -e @secrets.yml.example --skip-tags ddapi"
   - TEST_RUN="python tests/layout-checks.py job-list.txt"
+  - TEST_RUN="tests/shellcheck-test.sh"
   - TEST_RUN="tests/signed-off-by-test.sh"
 
 before_install:

--- a/roles/zuul/files/jobs/hoist.yaml
+++ b/roles/zuul/files/jobs/hoist.yaml
@@ -1,3 +1,4 @@
+---
 - job:
     name: ubuntu-hoist
     node: 'ubuntu-hoist'
@@ -20,5 +21,6 @@
     builders:
       - zuul-git-prep
       - shell: |
-          ./tests/signed-off-by-test.sh
           python tests/layout-checks.py job-list.txt
+          ./tests/shellcheck-test.sh
+          ./tests/signed-off-by-test.sh

--- a/tests/shellcheck-test.sh
+++ b/tests/shellcheck-test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sudo apt-get install -y shellcheck
+
+find . -name '*.sh' -print0 | xargs -n1 -0 shellcheck -s bash


### PR DESCRIPTION
Now, all shell scripts are linted for best practices.

Requires: #64, #66, #70, and #71
Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>