### PR TITLE
Fix vagrant-inject-pubkey.sh for best practices

### DIFF
--- a/tools/vagrant-inject-pubkey.sh
+++ b/tools/vagrant-inject-pubkey.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 pip install shyaml
-PUBKEY=$(cat /vagrant/secrets.yml.example | shyaml get-value secrets.ssh_keys.cideploy.public)
+PUBKEY=$(shyaml get-value secrets.ssh_keys.cideploy.public < /vagrant/secrets.yml.examle)
 
 if grep -q "$PUBKEY" ~ubuntu/.ssh/authorized_keys ; then
     echo Key already authorized


### PR DESCRIPTION
Script was updated in anticipation of `shellcheck` being added to CI
tests.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>