### PR TITLE
Add our check status as gate requirement

### DIFF
--- a/roles/zuul/templates/etc/zuul/config/layout.yaml
+++ b/roles/zuul/templates/etc/zuul/config/layout.yaml
@@ -39,6 +39,8 @@ pipelines:
           label: 'approved'
         - event: pr-comment
           comment: (?i)gate-recheck
+    require:
+      status: "anne-bonny:check_github:success"
     start:
       github:
         comment: true


### PR DESCRIPTION
We can now require that we've already tested the change in the check
pipeline. This turns it on for our gate_github pipeline.

We'll have to change the user should we change how we're setting status.
The context in the middle comes from the name of our check pipeline.

closes BonnyCI/projman#75