### PR TITLE
Fix hoist-checks test logging

### DIFF
--- a/roles/zuul/files/jobs/hoist.yaml
+++ b/roles/zuul/files/jobs/hoist.yaml
@@ -24,3 +24,6 @@
           python tests/layout-checks.py job-list.txt
           ./tests/shellcheck-test.sh
           ./tests/signed-off-by-test.sh
+
+    publishers:
+      - console-log


### PR DESCRIPTION
Publish the hoist-checks console log to the logs host.

Closes: BonnyCI/projman#96
Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>