### PR TITLE
Run a better test in hoist's gate

### DIFF
--- a/roles/zuul/templates/etc/zuul/config/layout.yaml
+++ b/roles/zuul/templates/etc/zuul/config/layout.yaml
@@ -70,7 +70,7 @@ projects:
       - ansible-syntax
       - hoist-checks
     gate_github:
-      - echo-true
+      - ubuntu-hoist
 
   - name: BonnyCI/sandbox
     check_github:


### PR DESCRIPTION
Run the multinode test instead of echo-true in hoist's gate pipeline.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>