### PR TITLE
Update link to contribution lore

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,4 +94,4 @@ To tear down the entire stack when you're done::
 Contributing
 ============
 
-See `our documentation on contributing <https://github.com/BonnyCI/lore/tree/master/contributing>`_.
+See `our documentation on contributing <https://github.com/BonnyCI/lore/tree/master/developers/contributing>`_.


### PR DESCRIPTION
Previously, the link to our contribution lore pointed to the old
location (resulting in a 404). Now it points to the new location.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>