### PR TITLE
Add bonnyci-run-pipeline job for executing in-repo test scripts

### DIFF
--- a/roles/nodepool/files/etc/nodepool/elements/bonnyci-nodepool/element-deps
+++ b/roles/nodepool/files/etc/nodepool/elements/bonnyci-nodepool/element-deps
@@ -1,2 +1,3 @@
+devuser
 package-installs
 source-repositories

--- a/roles/nodepool/files/etc/nodepool/elements/bonnyci-nodepool/install.d/90-test-logs-dir
+++ b/roles/nodepool/files/etc/nodepool/elements/bonnyci-nodepool/install.d/90-test-logs-dir
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Copyright (C) 2011-2013 OpenStack Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,6 +20,8 @@ if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
 fi
 set -e
 
-# Our use requires zuul be installed so that we can call zuul-cloner
-# The source is put in place by the source-repositories element.
-pip2 install /opt/zuul/
+# Create a log directory for tests to stuff things to be archived by publisher.
+# This path is also set in the job definition and exported to in-repo test
+# scripts, at ./roles/zuul/files/jobs/bonnyci.yaml.
+mkdir -p /opt/bonnyci/logs
+chown bonnyci:bonnyci /opt/bonnyci/logs

--- a/roles/zuul/files/jobs/bonnyci.yaml
+++ b/roles/zuul/files/jobs/bonnyci.yaml
@@ -1,0 +1,49 @@
+- publisher:
+    name: bonnyci-logs
+    publishers:
+      - scp:
+          site: bonnyci-scp
+          files:
+            - target: 'logs/$LOG_PATH'
+              source: '/opt/bonnyci/logs/**'
+              keep-hierarchy: true
+              copy-after-failure: true
+
+- job-template:
+    name: 'bonnyci-run-{pipeline}'
+    id: 'bonnyci-run-pipeline-{pipeline}'
+    test_log_dir: /opt/bonnyci/logs/
+    builders:
+      - zuul-git-prep
+      - shell: |
+            #!/bin/bash -xe
+            if [[ ! -f .bonnyci/run.sh ]]; then
+                echo "ERROR: No test script found at .bonnyci/run.sh, skipping"
+                exit 1
+            elif [[ ! -x .bonnyci/run.sh ]]; then
+                echo "ERROR: Test script found at .bonnyci/run.sh but it is not executable"
+                exit 1
+            fi
+
+            export BONNYCI_TEST_PIPELINE={pipeline}
+            export BONNYCI_TEST_LOG_DIR={test_log_dir}
+
+            if ./.bonnyci/run.sh; then
+                echo ".bonnyci/run.sh test(s) passed :)"
+                exit 0
+            else
+                echo ".bonnyci/run.sh test(s) failed :("
+                exit 1
+            fi
+
+    publishers:
+      - console-log
+      - bonnyci-logs
+
+- project:
+    name: bonnyci-run-pipeline
+    jobs:
+        - 'bonnyci-run-pipeline-{pipeline}':
+            pipeline: check
+        - 'bonnyci-run-pipeline-{pipeline}':
+            pipeline: gate

--- a/roles/zuul/templates/etc/zuul/config/layout.yaml
+++ b/roles/zuul/templates/etc/zuul/config/layout.yaml
@@ -74,12 +74,9 @@ projects:
 
   - name: BonnyCI/sandbox
     check_github:
-      - echo-true
-      - noop
+      - bonnyci-run-check
     gate_github:
-      - echo-true
-      - noop
-
+      - bonnyci-run-gate
   - name: BonnyCI/zuul
     check_github:
       - tox_py27


### PR DESCRIPTION
This adds a job template that can be re-used to run custom in-repo
job scripts for specified pipelines.

The job indicates to the script the pipeline in which the job is being run
via the 'BONNYCI_TEST_PIPELINE' environment variable.  It also exposes
a local directory via 'BONNYCI_TEST_LOG_DIR' which users may fill with
test output to be archived by the new 'bonnyci-logs' publisher.

The new job has been added to the sandbox repo for experimenting.