### PR TITLE
Manage datadog monitors from file

### DIFF
--- a/bastion.yml
+++ b/bastion.yml
@@ -15,6 +15,11 @@
         - monitoring
       when: secrets is defined
     - bastion
+    - role: datadog-builder
+      datadog_builder_secrets:
+        api_key: "{{ secrets.datadog.api_key }}"
+        app_key: "{{ secrets.datadog.ansible_app_key }}"
+      when: secrets is defined
     - role: ansible-runner
       ansible_runner_job: system-ansible
       ansible_playbook: bastion.yml

--- a/roles/datadog-builder/defaults/main.yml
+++ b/roles/datadog-builder/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+datadog_builder_git_repo_url: https://github.com/bonnyci/datadog-builder
+datadog_builder_git_branch: master
+datadog_builder_git_update: yes
+
+datadog_builder_monitor_url: https://github.com/bonnyci/datadog-monitors
+datadog_builder_monitor_update: yes
+datadog_builder_monitor_branch: master
+datadog_builder_monitor_file: monitors.yml
+
+datadog_builder_secrets: {}

--- a/roles/datadog-builder/tasks/datadog-builder.yml
+++ b/roles/datadog-builder/tasks/datadog-builder.yml
@@ -1,0 +1,66 @@
+---
+- name: Install deps
+  apt:
+    name: "{{ item }}"
+    state: installed
+    update_cache: true
+  with_items:
+    - git
+    - cron
+
+- name: Create source directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
+  with_items:
+    - /opt/source
+    - /opt/venvs
+    - /etc/datadog-builder
+
+- name: create datadog-builder user
+  user:
+    name: datadog-builder
+    home: /var/lib/datadog-builder
+    state: present
+
+- name: Create datadog-builder secrets
+  copy:
+    dest: /etc/datadog-builder/datadog-secrets.yml
+    content: "{{ datadog_builder_secrets | default({}) | to_nice_yaml(indent=2) }}"
+    mode: 0600
+    owner: datadog-builder
+
+- name: Checkout datadog-builder
+  git:
+    dest: /opt/source/datadog-builder
+    repo: "{{ datadog_builder_git_repo_url }}"
+    version: "{{ datadog_builder_git_branch }}"
+    update: "{{ datadog_builder_git_update }}"
+  register: datadog_builder_git
+
+- name: Install datadog-builder
+  pip:
+    extra_args: -U
+    name: /opt/source/datadog-builder
+    virtualenv: /opt/venvs/datadog-builder
+  when: datadog_builder_git.changed
+
+- name: Update monitors repo
+  git:
+    dest: "{{ datadog_builder_monitor_dir }}"
+    repo: "{{ datadog_builder_monitor_url }}"
+    update: "{{ datadog_builder_monitor_update }}"
+    version: "{{ datadog_builder_monitor_branch }}"
+
+- name: Setup cron job
+  cron:
+    name: datadog-builder
+    user: datadog-builder
+    minute: "*/15"
+    job: >
+      /opt/venvs/datadog-builder/bin/datadog-builder
+      --auth-config /etc/datadog-builder/datadog-secrets.yml
+      update {{ datadog_builder_monitor_dir }}/{{ datadog_builder_monitor_file }}

--- a/roles/datadog-builder/tasks/main.yml
+++ b/roles/datadog-builder/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- include: datadog-builder.yml
+  tags:
+    - datadog-builder

--- a/roles/datadog-builder/vars/main.yml
+++ b/roles/datadog-builder/vars/main.yml
@@ -1,0 +1,1 @@
+datadog_builder_monitor_dir: /opt/source/datadog-monitors


### PR DESCRIPTION
So datadog-builder is basically jenkins-job-builder for datadog. It's
kind of ruff (pun intended) but creates and deletes monitors on datadog
based on the entries in a config file.

This is the bastion equivalent that is checking out and running the jobs
on a cron job. The idea in future would be to put this on a CI job or
something so monitors are updated whenever the config file is changed.

I know it is basically what ansible gives us, but it will give us a bit
more control over the tags, monitor locking and whatever else.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>