### PR TITLE
[1 of 2] Add another subnode to the multinode label

### DIFF
--- a/inventory/group_vars/production
+++ b/inventory/group_vars/production
@@ -16,7 +16,7 @@ nodepool_labels:
   - name: ubuntu-hoist
     image: ubuntu-xenial
     min-ready: 0
-    subnodes: 2
+    subnodes: 3
     ready-script: subnode-ssh.sh
     providers:
       - name: cicloud


### PR DESCRIPTION
In order to add a logs subnode to the multinode test, we first need to increase
the number of subnodes. Once nodepool reconfigures with the new label count,
we can add the node info to the inventory script.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>