### PR TITLE
[2 of 2] Add another subnode to the multinode label

### DIFF
--- a/inventory/group_vars/production
+++ b/inventory/group_vars/production
@@ -16,7 +16,7 @@ nodepool_labels:
   - name: ubuntu-hoist
     image: ubuntu-xenial
     min-ready: 0
-    subnodes: 2
+    subnodes: 3
     ready-script: subnode-ssh.sh
     providers:
       - name: cicloud

--- a/inventory/nodepool.py
+++ b/inventory/nodepool.py
@@ -69,10 +69,10 @@ def get_inventory(subnodes):
     output['zookeeper'] = {'hosts': ['nodepool.multinode']}
     output['zuul'] = {'hosts': ['zuul.multinode']}
     output['mysql'] = {'hosts': ['zuul.multinode']}
-    #output['log'] = {'hosts': ['logs.multinode']}
+    output['log'] = {'hosts': ['logs.multinode']}
     output['multinode'] = {'hosts': ['nodepool.multinode',
                                      'zuul.multinode',
-                                     #'logs.multinode',
+                                     'logs.multinode',
                                      ]}
 
     return output


### PR DESCRIPTION
After the subnode count has increased, add the new subnode to our
dynamic inventory script for the multinode test.

Depends-On: BonnyCI/hoist#83
Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>