### PR TITLE
Make the hoist jobs fail on the first error

### DIFF
--- a/roles/zuul/files/jobs/hoist.yaml
+++ b/roles/zuul/files/jobs/hoist.yaml
@@ -7,9 +7,10 @@
       - zuul-git-prep
       - install-ansible
       - shell: |
+          #!/bin/bash -ex
           source /opt/venvs/ansible/bin/activate
           ansible-playbook -i inventory/nodepool.py install-ci.yml --skip-tags monitoring -e @secrets.yml.example
-          ansible-playbook -i inventory/nodepool.py  tests/validate-ci.yml
+          ansible-playbook -i inventory/nodepool.py tests/validate-ci.yml
 
     publishers:
       - console-log
@@ -21,6 +22,7 @@
     builders:
       - zuul-git-prep
       - shell: |
+          #!/bin/bash -ex
           python tests/layout-checks.py job-list.txt
           ./tests/shellcheck-test.sh
           ./tests/signed-off-by-test.sh


### PR DESCRIPTION
Run the jobs using `bash -e` so that the first non-zero exit code fails the
entire job rather than running all commands to completion.

For the ubuntu-hoist job, this will prevent the validate playbook from running
if the deploy playbook fails, making the deploy failure easier to spot.

For the hoist-checks job, this will correctly treat any script failure
as a job failure, instead of only failing if the final script fails.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>