### PR TITLE
Enrich our layout and job validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore temporary files
 tmp/
+job-list.txt
 
 # Ignore Ansible files
 upstream_roles/

--- a/roles/zuul/files/jobs/hoist.yaml
+++ b/roles/zuul/files/jobs/hoist.yaml
@@ -23,6 +23,7 @@
       - zuul-git-prep
       - shell: |
           #!/bin/bash -ex
+          ./tests/test-zuul-jobs.sh job-list.txt
           python tests/layout-checks.py job-list.txt
           ./tests/shellcheck-test.sh
           ./tests/signed-off-by-test.sh

--- a/tests/test-zuul-jobs.sh
+++ b/tests/test-zuul-jobs.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -xe
+# This tests the JJB syntax of our job definitions, and generates a
+# job-list.txt for use in the layout-checks.py test.
+
+jobs_dir="roles/zuul/files/jobs/"
+jobs_out=$1
+if [ -z "$jobs_out" ]; then
+    echo "ERROR: Must specify a file for jobs list output"
+    exit 1
+fi
+
+temp_dir=$(mktemp -d)
+trap 'rm -rf $temp_dir' EXIT
+
+virtualenv "$temp_dir"
+source "$temp_dir"/bin/activate
+pip install jenkins-job-builder
+jenkins-jobs -l debug test -o "$temp_dir"/jobs "$jobs_dir"
+
+find "$temp_dir"/jobs -printf "%f\n" > "$jobs_out"


### PR DESCRIPTION
layout-checks.py currently does not actuall test that jobs referenced
in zuul's layout actually exist as job definitions elsewhere.  This updates
our testing to validate our job definitions and generate a job-list.txt, then
validate zuul's layout against that to find any non-existent jobs.  This
also enables the empty check + gate pipeline tests

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>