### PR TITLE
Add job for BonnyCI integration in BonnyCI/lore

### DIFF
--- a/roles/zuul/files/jobs/lore.yaml
+++ b/roles/zuul/files/jobs/lore.yaml
@@ -1,0 +1,14 @@
+- job:
+    name: lore
+    node: 'ubuntu-xenial'
+
+    builders:
+      - zuul-git-prep
+      - shell: |
+          #!/bin/bash -ex
+          ./tests/markdownlint-cli-test.sh
+          ./tests/textlint-test.sh
+          ./tests/shellcheck-test.sh
+          ./tests/signed-off-by-test.sh
+    publishers:
+      - console-log

--- a/roles/zuul/templates/etc/zuul/config/layout.yaml
+++ b/roles/zuul/templates/etc/zuul/config/layout.yaml
@@ -72,6 +72,12 @@ projects:
     gate_github:
       - ubuntu-hoist
 
+  - name: BonnyCI/lore
+    check_github:
+      - lore
+    gate_github:
+      - lore
+
   - name: BonnyCI/sandbox
     check_github:
       - echo-true


### PR DESCRIPTION
Added roles/zuul/files/jobs/lore.yaml and modified
roles/zuul/templates/etc/zuul/config/layout.yaml so that BonnyCI/lore
will be tested by BonnyCI.

Related-Issue: BonnyCI/lore#44
Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>