### PR TITLE
Remove deprecated nodepool argument

### DIFF
--- a/roles/nodepool/files/etc/systemd/system/nodepool-deleter.service
+++ b/roles/nodepool/files/etc/systemd/system/nodepool-deleter.service
@@ -7,7 +7,7 @@ Type=simple
 User=nodepool
 Group=nodepool
 EnvironmentFile=-/etc/default/nodepool
-ExecStart=/bin/sh -c "${PREFIX}/bin/nodepoold -d --no-builder --no-launches --no-webapp -l /etc/nodepool/nodepool-deleter_logging.conf"
+ExecStart=/bin/sh -c "${PREFIX}/bin/nodepoold -d --no-launches --no-webapp -l /etc/nodepool/nodepool-deleter_logging.conf"
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/nodepool/files/etc/systemd/system/nodepool-launcher.service
+++ b/roles/nodepool/files/etc/systemd/system/nodepool-launcher.service
@@ -7,7 +7,7 @@ Type=simple
 User=nodepool
 Group=nodepool
 EnvironmentFile=-/etc/default/nodepool
-ExecStart=/bin/sh -c "${PREFIX}/bin/nodepoold -d --no-builder --no-deletes --no-webapp -l /etc/nodepool/nodepool-launcher_logging.conf"
+ExecStart=/bin/sh -c "${PREFIX}/bin/nodepoold -d --no-deletes --no-webapp -l /etc/nodepool/nodepool-launcher_logging.conf"
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/nodepool/files/etc/systemd/system/nodepoold.service
+++ b/roles/nodepool/files/etc/systemd/system/nodepoold.service
@@ -7,7 +7,7 @@ Type=simple
 User=nodepool
 Group=nodepool
 EnvironmentFile=-/etc/default/nodepool
-ExecStart=/bin/sh -c "${PREFIX}/bin/nodepoold -d --no-builder --no-deletes --no-launches -l /etc/nodepool/nodepoold_logging.conf"
+ExecStart=/bin/sh -c "${PREFIX}/bin/nodepoold -d --no-deletes --no-launches -l /etc/nodepool/nodepoold_logging.conf"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
As of commit openstack-infra/nodepool@1e627a9 the nodepool argument `--no-builder` is deprecated,
and a separate builder process is required. Remove the argument from the
service files as suggested by the deprecation warning logged in the
nodepool log files.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>