### PR TITLE
Use newer --config flag on datadog-builder

### DIFF
--- a/roles/datadog-builder/tasks/datadog-builder.yml
+++ b/roles/datadog-builder/tasks/datadog-builder.yml
@@ -62,5 +62,5 @@
     minute: "*/15"
     job: >
       /opt/venvs/datadog-builder/bin/datadog-builder
-      --auth-config /etc/datadog-builder/datadog-secrets.yml
+      --config /etc/datadog-builder/datadog-secrets.yml
       update {{ datadog_builder_monitor_dir }}/{{ datadog_builder_monitor_file }}


### PR DESCRIPTION
This got renamed recently and prevents running.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>