### PR TITLE
Fix 'recheck' regexes to be more strict

### DIFF
--- a/roles/zuul/templates/etc/zuul/config/layout.yaml
+++ b/roles/zuul/templates/etc/zuul/config/layout.yaml
@@ -14,7 +14,7 @@ pipelines:
             - pr-change
             - pr-reopen
         - event: pr-comment
-          comment: (?i)recheck
+          comment: (?i)^\s*recheck\s*$
     start:
       github:
         status: true
@@ -38,7 +38,7 @@ pipelines:
         - event: pr-label
           label: 'approved'
         - event: pr-comment
-          comment: (?i)gate-recheck
+          comment: (?i)^\s*gate-recheck\s*$
     require:
       status: "anne-bonny:check_github:success"
     start:


### PR DESCRIPTION
Currently, pr-comment can be triggered by any comment containing our
recheck term. This fixes the regex so that you must only have the term
'recheck', or the term 'gate-recheck' in your comment.

Fixes BonnyCI/projman#101

Signed-off-by: Bradon Kanyid <rattboi@gmail.com>