### PR TITLE
Ensure node/npm are installed for lore testing

### DIFF
--- a/roles/zuul/files/jobs/lore.yaml
+++ b/roles/zuul/files/jobs/lore.yaml
@@ -6,6 +6,10 @@
       - zuul-git-prep
       - shell: |
           #!/bin/bash -ex
+          sudo apt-get install -yqq curl
+          curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh | bash
+          source ~/.bashrc
+          nvm install stable && nvm use stable
           ./tests/markdownlint-cli-test.sh
           ./tests/textlint-test.sh
           ./tests/shellcheck-test.sh


### PR DESCRIPTION
lore's markdownlint and textlint tests rely on npm to install their
dependencies.

Relevant failure:
http://logs.bonnyci.com/check_github/BonnyCI/lore/48/1485995068.93/lore/console.html

Signed-off-by: Cullen Taylor <CullenTaylor@outlook.com>