### PR TITLE
Remove zuul merger datadog monitor setup

### DIFF
--- a/roles/dd-zuul/tasks/main.yml
+++ b/roles/dd-zuul/tasks/main.yml
@@ -3,15 +3,3 @@
     src: zuul_server.py
     dest: "{{ datadog_file_dir }}/zuul_server.py"
   notify: restart dd-agent
-- name: monitor zuul merger count
-  datadog_monitor:
-    api_key: "{{ secrets.datadog.api_key }}"
-    app_key: "{{ secrets.datadog.ansible_app_key }}"
-    name: zuul merger count
-    state: present
-    type: "metric alert"
-    message: "no zuul mergers"
-    query: 'min(last_5m):avg:gearman.workers_by_task{host:zuul,task:merger:merge} < 1'
-  vars:
-    ansible_python_interpreter: /opt/datadog/bin/python
-  tags: ddapi


### PR DESCRIPTION
Monitors should be set up on the datadog-monitors site rather than in
ansible so we can distinguish between different environments. eg. Don't
install something on datadog in testing.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>