### PR TITLE
Fix nvm being in the path by sourcing directly

### DIFF
--- a/roles/zuul/files/jobs/lore.yaml
+++ b/roles/zuul/files/jobs/lore.yaml
@@ -8,7 +8,8 @@
           #!/bin/bash -ex
           sudo apt-get install -yqq curl
           curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh | bash
-          source ~/.bashrc
+          export NVM_DIR="/home/bonnyci/.nvm"
+          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
           nvm install stable && nvm use stable
           ./tests/markdownlint-cli-test.sh
           ./tests/textlint-test.sh


### PR DESCRIPTION
nvm is installed, but not available in the path unless you source the
right things. Sourcing the .bashrc didn't work (and you can't be sure
exactly what that's going to be), so let's just source the script that
nvm creates for this duty.

Signed-off-by: Bradon Kanyid <rattboi@gmail.com>