### PR TITLE
Install node/npm via apt rather than nvm

### DIFF
--- a/roles/zuul/files/jobs/lore.yaml
+++ b/roles/zuul/files/jobs/lore.yaml
@@ -6,10 +6,7 @@
       - zuul-git-prep
       - shell: |
           #!/bin/bash -ex
-          sudo apt-get install -yqq curl
-          curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh | bash
-          source ~/.bashrc
-          nvm install stable && nvm use stable
+          sudo apt-get install -qq nodejs npm
           ./tests/markdownlint-cli-test.sh
           ./tests/textlint-test.sh
           ./tests/shellcheck-test.sh


### PR DESCRIPTION
nvm isn't getting us anything as far as pinning goes and is proving
finicky.

Signed-off-by: Cullen Taylor <CullenTaylor@outlook.com>