### PR TITLE
Move the zuul-merger to its own host

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -31,21 +31,44 @@
       tags:
         - monitoring
 
-- name: Install zuul
+- name: Install zuul server and launcher
   hosts: zuul
   become: yes
-  tags: ['zuul']
+  tags:
+    - zuul
+    - zuul-server
+    - zuul-launcher
   roles:
     - role: dd-gearman
       tags:
         - monitoring
 
     - role: zuul
-      zuul_merger_git_dir: "{{ bonnyci_zuul_merger_git_dir }}"
 
     - role: dd-zuul
       tags:
         - monitoring
+
+    - role: logrotate
+      logrotate_configs:
+        - name: zuul
+          path: /var/log/zuul/*log
+          options:
+            - compress
+            - missingok
+            - rotate 30
+            - daily
+            - notifempty
+
+- name: Install zuul mergers
+  hosts: mergers
+  become: yes
+  tags:
+    - zuul
+    - zuul-merger
+  roles:
+    - role: zuul
+      zuul_merger_git_dir: "{{ bonnyci_zuul_merger_git_dir }}"
 
     - role: apache
       apache_mods_enabled: "{{ bonnyci_zuul_apache_mods_enabled }}"

--- a/inventory/allinone
+++ b/inventory/allinone
@@ -10,6 +10,9 @@ allinone
 [zuul]
 allinone
 
+[mergers]
+allinone
+
 [mysql]
 allinone
 

--- a/inventory/ci
+++ b/inventory/ci
@@ -4,6 +4,9 @@ nodepool.bonnyci-internal.portbleu.com
 [zuul]
 zuul.bonnyci-internal.portbleu.com
 
+[mergers]
+merger01.bonnyci-internal.portbleu.com
+
 [mysql]
 zuul.bonnyci-internal.portbleu.com
 
@@ -16,4 +19,5 @@ logs.bonnyci-internal.portbleu.com
 [production]
 nodepool.bonnyci-internal.portbleu.com
 zuul.bonnyci-internal.portbleu.com
+merger01.bonnyci-internal.portbleu.com
 logs.bonnyci-internal.portbleu.com

--- a/inventory/group_vars/mergers
+++ b/inventory/group_vars/mergers
@@ -1,0 +1,22 @@
+bonnyci_zuul_apache_mods_enabled:
+  - cgi.load
+
+bonnyci_zuul_apache_vhosts:
+  - name: git
+    server_name: "{{ bonnyci_zuul_apache_server_name | default('merger') }}"
+    vhost_extra: |
+      <LocationMatch "^/p/">
+         Require all granted
+      </LocationMatch>
+
+      SetEnv GIT_PROJECT_ROOT {{ bonnyci_zuul_merger_git_dir }}
+      SetEnv GIT_HTTP_EXPORT_ALL 1
+
+      AliasMatch ^/p/(.*/objects/[0-9a-f]{2}/[0-9a-f]{38})$ {{ bonnyci_zuul_merger_git_dir }}/$1
+      AliasMatch ^/p/(.*/objects/pack/pack-[0-9a-f]{40}.(pack|idx))$ {{ bonnyci_zuul_merger_git_dir }}/$1
+      ScriptAlias /p/ /usr/lib/git-core/git-http-backend/
+
+bonnyci_zuul_merger_git_dir: /var/lib/zuul/git
+
+zuul_components:
+  - zuul-merger

--- a/inventory/group_vars/production
+++ b/inventory/group_vars/production
@@ -43,4 +43,5 @@ zuul_connections:
   github:
     driver: github
     api_token: "{{ secrets.zuul_github_api_key }}"
-zuul_merger_url: http://zuul.bonnyci-internal.portbleu.com/p
+zuul_merger_url: http://merger01.bonnyci-internal.portbleu.com/p
+zuul_gearman_server: zuul.bonnyci-internal.portbleu.com

--- a/inventory/group_vars/vagrant
+++ b/inventory/group_vars/vagrant
@@ -1,6 +1,8 @@
 bastion_clouds:
   - bastioncloud
 
+bonnyci_zuul_apache_server_name: merger.vagrant
+
 datadog_enabled: no
 
 hoist_repo: /vagrant/.git
@@ -23,4 +25,5 @@ zuul_statsd_enable: no
 zuul_connections:
   github:
     driver: github
-zuul_merger_url: "http://zuul.vagrant/p"
+zuul_merger_url: "http://merger.vagrant/p"
+zuul_gearman_server: zuul.vagrant

--- a/inventory/group_vars/zuul
+++ b/inventory/group_vars/zuul
@@ -17,3 +17,8 @@ bonnyci_zuul_apache_vhosts:
       ScriptAlias /p/ /usr/lib/git-core/git-http-backend/
 
 bonnyci_zuul_merger_git_dir: /var/lib/zuul/git
+
+zuul_components:
+  - zuul-launcher
+  - zuul-merger
+  - zuul-server

--- a/inventory/host_vars/zuul.multinode
+++ b/inventory/host_vars/zuul.multinode
@@ -1,5 +1,4 @@
-zookeeper_myid: 1
-
+#TODO(jesusaur): add merger.multinode subnode to ubuntu-hoist
 zuul_components:
   - zuul-launcher
   - zuul-merger

--- a/inventory/nodepool.py
+++ b/inventory/nodepool.py
@@ -68,6 +68,7 @@ def get_inventory(subnodes):
     output['nodepool'] = {'hosts': ['nodepool.multinode']}
     output['zookeeper'] = {'hosts': ['nodepool.multinode']}
     output['zuul'] = {'hosts': ['zuul.multinode']}
+    output['mergers'] = {'hosts': ['zuul.multinode']}
     output['mysql'] = {'hosts': ['zuul.multinode']}
     #output['log'] = {'hosts': ['logs.multinode']}
     output['multinode'] = {'hosts': ['nodepool.multinode',

--- a/inventory/vagrant
+++ b/inventory/vagrant
@@ -7,6 +7,9 @@ nodepool.vagrant ansible_user=ubuntu
 [zuul]
 zuul.vagrant ansible_user=ubuntu
 
+[mergers]
+merger.vagrant ansible_user=ubuntu
+
 [mysql]
 zuul.vagrant ansible_user=ubuntu
 
@@ -15,7 +18,8 @@ logs.vagrant ansible_user=ubuntu
 
 [vagrant:children]
 bastion
-zuul
-nodepool
-mysql
 log
+mergers
+mysql
+nodepool
+zuul

--- a/roles/zuul/handlers/main.yml
+++ b/roles/zuul/handlers/main.yml
@@ -15,10 +15,7 @@
   service:
     name: "{{ item }}"
     state: restarted
-  with_items:
-    - zuul-launcher
-    - zuul-merger
-    - zuul-server
+  with_items: "{{ zuul_components }}"
   when: zuul_check_server.rc == 0 and (zuul_allow_restart_services | bool)
   register: zuul_restarted
 

--- a/roles/zuul/tasks/launcher.yml
+++ b/roles/zuul/tasks/launcher.yml
@@ -1,0 +1,16 @@
+- name: Install logging config
+  template:
+    src: "etc/zuul/logging.conf"
+    dest: "/etc/zuul/{{ item }}-logging.conf"
+    owner: zuul
+  with_items:
+    - launcher
+  notify: Restart zuul
+
+- name: Install job definitions
+  synchronize:
+    src: files/jobs/
+    dest: /var/lib/zuul/jobs/
+    rsync_opts:
+      - "--chown=zuul:zuul"
+  notify: Reconfigure zuul-launcher

--- a/roles/zuul/tasks/main.yml
+++ b/roles/zuul/tasks/main.yml
@@ -29,7 +29,7 @@
     mode: 0755
     owner: zuul
     group: zuul
-  items:
+  with_items:
     - /etc/zuul/config
     - /var/log/zuul
 
@@ -108,61 +108,33 @@
     owner: zuul
   notify: Restart zuul
 
-- name: Install logging config
-  template:
-    src: "etc/zuul/logging.conf"
-    dest: "/etc/zuul/{{ item }}-logging.conf"
-    owner: zuul
-  with_items:
-    - gearman
-    - launcher
-    - merger
-    - server
-  notify: Restart zuul
-
-- name: Install layout.yaml
-  template:
-    src: etc/zuul/config/layout.yaml
-    dest: /etc/zuul/config/layout.yaml
-    owner: zuul
-  notify: Reload zuul-server
-
-- name: install magic functions file
-  copy:
-    src: etc/zuul/config/bonnyci_functions.py
-    dest: /etc/zuul/config/bonnyci_functions.py
-    owner: zuul
-  notify: Reload zuul-server
-
-- name: Install job definitions
-  synchronize:
-    src: files/jobs/
-    dest: /var/lib/zuul/jobs/
-    rsync_opts:
-      - "--chown=zuul:zuul"
-  notify: Reconfigure zuul-launcher
-
 - name: Install service environment configs
   template:
     src: etc/default/zuul
     dest: /etc/default/{{ item }}
-  with_items:
-    - zuul-launcher
-    - zuul-merger
-    - zuul-server
+  with_items: "{{ zuul_components }}"
   notify: Restart zuul
 
 - name: Install systemd unit files
   template:
     src: etc/systemd/system/zuul.service
     dest: /etc/systemd/system/{{ item }}.service
-  with_items:
-    - zuul-launcher
-    - zuul-merger
-    - zuul-server
+  with_items: "{{ zuul_components }}"
   notify:
     - Reload systemd units
     - Restart zuul
+
+- name: Configure zuul-server
+  include: server.yml
+  when: "'zuul-server' in zuul_components"
+
+- name: Configure zuul-launcher
+  include: launcher.yml
+  when: "'zuul-launcher' in zuul_components"
+
+- name: Configure zuul-merger
+  include: merger.yml
+  when: "'zuul-merger' in zuul_components"
 
 - meta: flush_handlers
 
@@ -171,7 +143,4 @@
     name: "{{ item }}"
     state: started
     enabled: yes
-  items:
-    - zuul-launcher
-    - zuul-merger
-    - zuul-server
+  with_items: "{{ zuul_components }}"

--- a/roles/zuul/tasks/merger.yml
+++ b/roles/zuul/tasks/merger.yml
@@ -1,0 +1,9 @@
+- name: Install logging config
+  template:
+    src: "etc/zuul/logging.conf"
+    dest: "/etc/zuul/{{ item }}-logging.conf"
+    owner: zuul
+  with_items:
+    - merger
+  notify: Restart zuul
+

--- a/roles/zuul/tasks/server.yml
+++ b/roles/zuul/tasks/server.yml
@@ -1,0 +1,23 @@
+- name: Install logging config
+  template:
+    src: "etc/zuul/logging.conf"
+    dest: "/etc/zuul/{{ item }}-logging.conf"
+    owner: zuul
+  with_items:
+    - gearman
+    - server
+  notify: Restart zuul
+
+- name: Install layout.yaml
+  template:
+    src: etc/zuul/config/layout.yaml
+    dest: /etc/zuul/config/layout.yaml
+    owner: zuul
+  notify: Reload zuul-server
+
+- name: install magic functions file
+  copy:
+    src: etc/zuul/config/bonnyci_functions.py
+    dest: /etc/zuul/config/bonnyci_functions.py
+    owner: zuul
+  notify: Reload zuul-server

--- a/tests/validate-ci.yml
+++ b/tests/validate-ci.yml
@@ -9,11 +9,8 @@
   hosts: zuul
   tasks:
     - name: zuul services are running
-      command: pgrep -f {{ item }}
-      with_items:
-        - /opt/venvs/zuul/bin/zuul-server
-        - /opt/venvs/zuul/bin/zuul-merger
-        - /opt/venvs/zuul/bin/zuul-launcher
+      command: pgrep -f /opt/venvs/zuul/bin/{{ item }}
+      with_items: "{{ zuul_components }}"
 
     - name: gearman services are running
       shell: netstat -antlp | grep 4730

--- a/tests/validate-ci.yml
+++ b/tests/validate-ci.yml
@@ -5,13 +5,18 @@
     - name: mysql is running
       command: pgrep -f /usr/sbin/mysql
 
-- name: Validate zuul
-  hosts: zuul
+- name: Validate zuul services
+  hosts:
+    - zuul
+    - mergers
   tasks:
     - name: zuul services are running
       command: pgrep -f /opt/venvs/zuul/bin/{{ item }}
       with_items: "{{ zuul_components }}"
 
+- name: Validate gearman status
+  hosts: zuul
+  tasks:
     - name: gearman services are running
       shell: netstat -antlp | grep 4730
 


### PR DESCRIPTION
Refactor the zuul role to split up the server, launcher, and merger.
Include the server and launcher components on the original host, and
move the merger component to a dedicated host.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>