### PR TITLE
Add nodejs to provide node in lore job

### DIFF
--- a/roles/zuul/files/jobs/lore.yaml
+++ b/roles/zuul/files/jobs/lore.yaml
@@ -6,7 +6,8 @@
       - zuul-git-prep
       - shell: |
           #!/bin/bash -ex
-          sudo apt-get install -qq nodejs npm
+          sudo apt-get install -qq npm
+          sudo update-alternatives --install /usr/bin/node node /usr/bin/nodejs 10
           ./tests/markdownlint-cli-test.sh
           ./tests/textlint-test.sh
           ./tests/shellcheck-test.sh


### PR DESCRIPTION
Previously, our lore job installed nodejs and npm. nodejs is installed
as a dependency of npm, however, nodejs is not being set for the node
environemnt. This commit fixes that.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>