### PR TITLE
Use node 7.x PPA for lore job

### DIFF
--- a/roles/zuul/files/jobs/lore.yaml
+++ b/roles/zuul/files/jobs/lore.yaml
@@ -6,8 +6,8 @@
       - zuul-git-prep
       - shell: |
           #!/bin/bash -ex
-          sudo apt-get install -qq npm
-          sudo update-alternatives --install /usr/bin/node node /usr/bin/nodejs 10
+          curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
+          sudo apt-get install -qq nodejs
           ./tests/markdownlint-cli-test.sh
           ./tests/textlint-test.sh
           ./tests/shellcheck-test.sh


### PR DESCRIPTION
Previously, we were installing nodejs from the Ubuntu repository. Now we
are installing it from the node 7.x PPA.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>