### PR TITLE
Add npm to installed package in lore job

### DIFF
--- a/roles/zuul/files/jobs/lore.yaml
+++ b/roles/zuul/files/jobs/lore.yaml
@@ -7,7 +7,7 @@
       - shell: |
           #!/bin/bash -ex
           curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
-          sudo apt-get install -qq nodejs
+          sudo apt-get install -qq npm
           ./tests/markdownlint-cli-test.sh
           ./tests/textlint-test.sh
           ./tests/shellcheck-test.sh


### PR DESCRIPTION
Previously, we were installing only nodejs. Now we are also installing
npm.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>