### PR TITLE
Bump nodepool min-ready

### DIFF
--- a/inventory/group_vars/production
+++ b/inventory/group_vars/production
@@ -10,12 +10,12 @@ nodepool_gearman_servers:
 nodepool_labels:
   - name: ubuntu-xenial
     image: ubuntu-xenial
-    min-ready: 1
+    min-ready: 2
     providers:
       - name: cicloud
   - name: ubuntu-hoist
     image: ubuntu-xenial
-    min-ready: 0
+    min-ready: 1
     subnodes: 3
     ready-script: subnode-ssh.sh
     providers:


### PR DESCRIPTION
ubuntu-xenial is used for a bunch, bump it to 2 ready at all times.

Ubuntu-hoist is used for hoist, and it is rather expensive with
subnodes. Keep it at one ready.