### PR TITLE
Redesign gate pipeline layout

### DIFF
--- a/roles/zuul/templates/etc/zuul/config/layout.yaml
+++ b/roles/zuul/templates/etc/zuul/config/layout.yaml
@@ -35,28 +35,31 @@ pipelines:
     source: github
     trigger:
       github:
-        - event: pr-label
-          label: 'approved'
+        - event: status
+          status: "anne-bonny:check_github:success"
+        - event: pr-review
+          state: 'approve'
         - event: pr-comment
           comment: (?i)^\s*gate-recheck\s*$
     require:
       status: "anne-bonny:check_github:success"
+      approval:
+        - review: 2
+    reject:
+      approval:
+        - review: -2
     start:
       github:
-        comment: true
-        label: '-approved'
         status: true
     success:
       github:
         comment: false
         merge: true
-        label: 'approved'
         status: true
         status_url: *log_link
     failure:
       github:
         comment: true
-        label: '-approved'
         status: true
         status_url: *log_link
 


### PR DESCRIPTION
Trigger on our check status or a positive review, or a gate-recheck
comment.
Require a positive review from somebody with write access, and our check
status.
Reject on a negative review from somebody with write access.

Do not comment on gate start.
Do not trigger/remove labels.

Based on design from
https://github.com/BonnyCI/lore/blob/master/developers/contributing/designs/github-pr-check-gate.md

Signed-off-by: Jesse Keating <jkeating@j2solutions.net>