### PR TITLE
Add node-info builder to get basic debugging info

### DIFF
--- a/roles/zuul/files/jobs/common.yaml
+++ b/roles/zuul/files/jobs/common.yaml
@@ -40,3 +40,19 @@
               dest: .
           EOF
           zuul-cloner https://github.com/ -m $CLONEMAP $ZUUL_PROJECT
+
+
+# This is a simple builder to output basic node debugging info.
+# It can be added to the beginning of a job to make debugging easier.
+- builder:
+    name: node-info
+    builders:
+      - shell: |
+        #!/bin/bash -e
+        if [ -r /etc/nodepool/sub_nodes ] ; then
+            echo "Subnode info:"
+            cat /etc/nodepool/sub_nodes
+        fi
+
+        echo "Current environment:"
+        env

--- a/roles/zuul/files/jobs/hoist.yaml
+++ b/roles/zuul/files/jobs/hoist.yaml
@@ -4,6 +4,7 @@
     node: 'ubuntu-hoist'
 
     builders:
+      - node-info
       - zuul-git-prep
       - install-ansible
       - shell: |


### PR DESCRIPTION
Create a builder step to print out basic debugging info about the test node
and add the builder to the multinode test.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>