### PR TITLE
Make sure the system hostname is in /etc/hosts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ matrix:
 
 env:
   - TEST_RUN="ansible-playbook -i herp, bastion.yml install-ci.yml provision.yml tests/validate-ci.yml --syntax-check"
-  - TEST_RUN="ansible-playbook -i inventory/allinone bastion.yml install-ci.yml tests/validate-ci.yml -c docker -vv -e @secrets.yml.example --skip-tags ddapi"
-  - TEST_RUN="ansible-playbook -i inventory/allinone install-ci.yml tests/validate-ci.yml -c docker -vv -e @secrets.yml.example --skip-tags ddapi"
+  - TEST_RUN="ansible-playbook -i inventory/allinone bastion.yml install-ci.yml tests/validate-ci.yml -c docker -vv -e @secrets.yml.example --skip-tags monitoring,no-docker"
+  - TEST_RUN="ansible-playbook -i inventory/allinone install-ci.yml tests/validate-ci.yml -c docker -vv -e @secrets.yml.example --skip-tags monitoring,no-docker"
   - TEST_RUN="python tests/layout-checks.py job-list.txt"
   - TEST_RUN="tests/shellcheck-test.sh"
   - TEST_RUN="tests/signed-off-by-test.sh"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -8,3 +8,10 @@
     - jq
     - netcat
     - net-tools
+
+- name: Put hostname in /etc/hosts
+  lineinfile:
+    dest: /etc/hosts
+    regexp: '^127\.0\.0\.1'
+    line: '127.0.0.1 {{ ansible_hostname }} localhost'
+  tags: ['no-docker']


### PR DESCRIPTION
Scan /etc/hosts for a line starting with "127.0.0.1" and replace the line
with one listing both the short hostname (as reported by the system, up
to the first period) and "localhost".

The sudo utility will complain if it can't look up the system's hostname,
and adding a localhost alias in /etc/hosts is an easy way to avoid those
warnings.

Since docker can not edit /etc/hosts[1], add a tag for skipping tasks
docker can't perform. Also fix the docker commands to use the new 'monitoring'
tag that replaces the no-longer-existent 'ddapi' tag.

[1] https://github.com/docker/docker/issues/22281#issuecomment-214336587

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>