### PR TITLE
Remove `textlint` from BonnyCI

### DIFF
--- a/roles/zuul/files/jobs/lore.yaml
+++ b/roles/zuul/files/jobs/lore.yaml
@@ -10,7 +10,6 @@
           curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
           sudo apt-get install -y nodejs
           ./tests/markdownlint-cli-test.sh
-          ./tests/textlint-test.sh
           ./tests/shellcheck-test.sh
           ./tests/signed-off-by-test.sh
     publishers:


### PR DESCRIPTION
Discussion on BonnyCI/lore#54 led to the decision that textlint would
be removed from the CI sysytems.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>