### PR TITLE
Update zuul group_vars for split-out merger

### DIFF
--- a/inventory/group_vars/zuul
+++ b/inventory/group_vars/zuul
@@ -20,5 +20,4 @@ bonnyci_zuul_merger_git_dir: /var/lib/zuul/git
 
 zuul_components:
   - zuul-launcher
-  - zuul-merger
   - zuul-server


### PR DESCRIPTION
Now that the merger runs on a separate host, remove the component from
the zuul group vars. There are host vars in place for zuul.multinode
and allinone so that the tests will still put all three components on the
same host.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>