### PR TITLE
Set zuul_merger_url based on ansible_nodename

### DIFF
--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -6,3 +6,5 @@ zuul_statsd_enable: yes
 
 zuul_git_user_email: anne@bonnyci.org
 zuul_git_user_name: Anne Bonny
+
+zuul_merger_url: "http://{{ ansible_nodename }}/p"

--- a/inventory/group_vars/production
+++ b/inventory/group_vars/production
@@ -43,5 +43,4 @@ zuul_connections:
   github:
     driver: github
     api_token: "{{ secrets.zuul_github_api_key }}"
-zuul_merger_url: http://merger01.bonnyci-internal.portbleu.com/p
 zuul_gearman_server: zuul.bonnyci-internal.portbleu.com

--- a/inventory/group_vars/vagrant
+++ b/inventory/group_vars/vagrant
@@ -25,5 +25,4 @@ zuul_statsd_enable: no
 zuul_connections:
   github:
     driver: github
-zuul_merger_url: "http://merger.vagrant/p"
 zuul_gearman_server: zuul.vagrant


### PR DESCRIPTION
Since ansible and nodepool nodes can reach mergers using the same host name,
automatically build the url based on the full hostname ansible uses to reach
the mergers.

If we ever have to change the url that nodepool nodes reach the mergers at
(e.g. if we add another nodepool provider), we may need to set the merger
url in host_vars for every merger.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>