### PR TITLE
Move git repos to a different port

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -71,8 +71,8 @@
       zuul_merger_git_dir: "{{ bonnyci_zuul_merger_git_dir }}"
 
     - role: apache
-      apache_mods_enabled: "{{ bonnyci_zuul_apache_mods_enabled }}"
-      apache_vhosts: "{{ bonnyci_zuul_apache_vhosts }}"
+      apache_mods_enabled: "{{ bonnyci_zuul_merger_apache_mods_enabled }}"
+      apache_vhosts: "{{ bonnyci_zuul_merger_apache_vhosts }}"
 
     - role: dd-apache
       tags:

--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -7,4 +7,5 @@ zuul_statsd_enable: yes
 zuul_git_user_email: anne@bonnyci.org
 zuul_git_user_name: Anne Bonny
 
-zuul_merger_url: "http://{{ ansible_nodename }}/p"
+zuul_merger_apache_port: 8858
+zuul_merger_url: "http://{{ ansible_nodename }}:{{ zuul_merger_apache_port }}/p"

--- a/inventory/group_vars/mergers
+++ b/inventory/group_vars/mergers
@@ -1,9 +1,11 @@
-bonnyci_zuul_apache_mods_enabled:
+
+bonnyci_zuul_merger_apache_mods_enabled:
   - cgi.load
 
-bonnyci_zuul_apache_vhosts:
+bonnyci_zuul_merger_apache_vhosts:
   - name: git
     server_name: "{{ bonnyci_zuul_apache_server_name | default('merger') }}"
+    port: "{{ zuul_merger_apache_port }}"
     vhost_extra: |
       <LocationMatch "^/p/">
          Require all granted

--- a/inventory/group_vars/multinode
+++ b/inventory/group_vars/multinode
@@ -34,5 +34,5 @@ nodepool_zmq_publishers:
 zuul_connections:
   github:
     driver: github
-zuul_merger_url: "http://{{ zuul_ip }}/p"
+zuul_merger_url: "http://{{ zuul_ip }}:{{ zuul_merger_apache_port }}/p"
 zuul_statsd_enable: no


### PR DESCRIPTION
Having the git repos on port 80 conflicts with the status page and
probably other things in future. This URL is all handled via variables
so the port is irrelevant, move it to something arbitrary.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>