### PR TITLE
Add review requirements to gate layout

### DIFF
--- a/roles/zuul/templates/etc/zuul/config/layout.yaml
+++ b/roles/zuul/templates/etc/zuul/config/layout.yaml
@@ -41,6 +41,12 @@ pipelines:
           comment: (?i)^\s*gate-recheck\s*$
     require:
       status: "anne-bonny:check_github:success"
+      approval:
+        - review: 2
+    reject:
+      approval:
+        - review: -2
+
     start:
       github:
         comment: true


### PR DESCRIPTION
Require at least one code-review approval, and reject if there are any
changes requested, provided the review came from someone with write
access.

Since we don't yet have the ability to require a label, keep the label
as the primary pipeline trigger.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>