### PR TITLE
Create logfile for datadog-builder cronjob

### DIFF
--- a/roles/datadog-builder/tasks/datadog-builder.yml
+++ b/roles/datadog-builder/tasks/datadog-builder.yml
@@ -20,11 +20,25 @@
     - /opt/venvs
     - /etc/datadog-builder
 
+- name: create datadog-builder group
+  group:
+    name: datadog-builder
+    state: present
+
 - name: create datadog-builder user
   user:
     name: datadog-builder
+    group: datadog-builder
     home: /var/lib/datadog-builder
     state: present
+
+- name: Create log file
+  file:
+    path: /var/log/datadog-builder
+    state: directory
+    mode: 0755
+    owner: datadog-builder
+    group: datadog-builder
 
 - name: Create datadog-builder secrets
   copy:
@@ -64,3 +78,4 @@
       /opt/venvs/datadog-builder/bin/datadog-builder
       --config /etc/datadog-builder/datadog-secrets.yml
       update {{ datadog_builder_monitor_dir }}/{{ datadog_builder_monitor_file }}
+      2>&1 >> /var/log/datadog-builder/datadog-builder.log


### PR DESCRIPTION
Currently, this cronjob attempts to write to cron log, but since we
don't have an MTA installed, that output goes nowhere. Having the
error output go to a specific log is what we are doing for our other
cronjobs, so I think this makes sense.

Signed-off-by: Bradon Kanyid <rattboi@gmail.com>