### PR TITLE
Allow setting the listen address and port for zuul webapp

### DIFF
--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -14,6 +14,9 @@ zuul_statsd_enable: no
 zuul_statsd_host: 127.0.0.1
 zuul_statsd_port: 8125
 
+zuul_webapp_listen_address: 127.0.0.1
+zuul_webapp_port: 8001
+
 zuul_merger_url: 127.0.0.1
 zuul_merger_git_dir: /var/lib/zuul/git
 

--- a/roles/zuul/templates/etc/zuul/zuul.conf
+++ b/roles/zuul/templates/etc/zuul/zuul.conf
@@ -45,3 +45,7 @@ pidfile = /var/run/zuul-merger/zuul-merger.pid
 zuul_url = {{ zuul_merger_url }}
 git_user_email = {{ zuul_git_user_email }}
 git_user_name = {{ zuul_git_user_name }}
+
+[webapp]
+listen_address = {{ zuul_webapp_listen_address }}
+port = {{ zuul_webapp_port }}


### PR DESCRIPTION
We can set the listen address and port for the zuul status port. By
default the listen address is 0.0.0.0 and we should make that default
127.0.0.1 because we want to hide this route behind apache.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>