### PR TITLE
Set FQDN for zuul-merger's zuul_url

### DIFF
--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -8,4 +8,4 @@ zuul_git_user_email: anne@bonnyci.org
 zuul_git_user_name: Anne Bonny
 
 zuul_merger_apache_port: 8858
-zuul_merger_url: "http://{{ ansible_nodename }}:{{ zuul_merger_apache_port }}/p"
+zuul_merger_url: "http://{{ inventory_hostname }}:{{ zuul_merger_apache_port }}/p"


### PR DESCRIPTION
Slave nodes end up with 'search openstacklocal' in its resolv.conf
and require an FQDN here.