### PR TITLE
Use a better merger url

### DIFF
--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -8,4 +8,4 @@ zuul_git_user_email: anne@bonnyci.org
 zuul_git_user_name: Anne Bonny
 
 zuul_merger_apache_port: 8858
-zuul_merger_url: "http://{{ ansible_nodename }}:{{ zuul_merger_apache_port }}/p"
+zuul_merger_url: "http://{{ inventory_hostname }}:{{ zuul_merger_apache_port }}/p"


### PR DESCRIPTION
Use inventory_hostname instead of ansible_nodename becase the
inventory file uses full FQDNs, but the host doesn't know its own
FQDN.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>