### PR TITLE
Revert "Publicly log from the nodepool node"

### DIFF
--- a/roles/nodepool/meta/main.yml
+++ b/roles/nodepool/meta/main.yml
@@ -1,11 +1,5 @@
 ---
 dependencies:
-  - role: apache
-    apache_vhosts:
-      - name: nodepool
-        document_root: /var/log/nodepool/
-        document_root_options: +FollowSymLinks
-
   - role: python-app
     name: nodepool
     python_app_pipdeps:


### PR DESCRIPTION
This reverts commit b6196a5f4f696e45ddf71d333699b47599f53c0f.

Logging nodepool logs via apache was temporarily useful for debugging.
We shouldn't be doing this any more for both security and because it
adds more port 80 vhosts to apache.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>