### PR TITLE
Add zuul_connections to all hosts

### DIFF
--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -9,3 +9,8 @@ zuul_git_user_name: Anne Bonny
 
 zuul_merger_apache_port: 8858
 zuul_merger_url: "http://{{ inventory_hostname }}:{{ zuul_merger_apache_port }}/p"
+
+zuul_connections:
+  github:
+    driver: github
+    api_token: "{{ secrets.zuul_github_api_key }}"

--- a/inventory/group_vars/production
+++ b/inventory/group_vars/production
@@ -39,8 +39,4 @@ nodepool_statsd_enable: yes
 nodepool_zmq_publishers:
   - tcp://zuul.bonnyci-internal.portbleu.com:8888
 
-zuul_connections:
-  github:
-    driver: github
-    api_token: "{{ secrets.zuul_github_api_key }}"
 zuul_gearman_server: zuul.bonnyci-internal.portbleu.com


### PR DESCRIPTION
If we don't have the github connection in the deploy like in test
scenarios then the github connection isn't available in zuul and the
layout.yaml we add to all hosts isn't there. This means that the
layout.yaml fails validation and zuul doesn't start correctly.

Unfortunately zuul doesn't handle this failure well and instead of
failing completely gets stuck in a half loaded state where nothing
works.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>