### PR TITLE
Fully remove zuul_connections from group_vars

### DIFF
--- a/inventory/group_vars/allinone
+++ b/inventory/group_vars/allinone
@@ -11,7 +11,6 @@ nodepool_providers:
         min-ram: 2048
         diskimage: ubuntu-xenial
         private-key: /var/lib/nodepool/.ssh/id_rsa
-zuul_connections: {}
 
 bastion_clouds:
   - cicloud

--- a/inventory/group_vars/multinode
+++ b/inventory/group_vars/multinode
@@ -31,8 +31,5 @@ nodepool_statsd_enable: no
 nodepool_zmq_publishers:
   - "tcp://{{ zuul_ip }}:8888"
 
-zuul_connections:
-  github:
-    driver: github
 zuul_merger_url: "http://{{ zuul_ip }}:{{ zuul_merger_apache_port }}/p"
 zuul_statsd_enable: no

--- a/inventory/group_vars/vagrant
+++ b/inventory/group_vars/vagrant
@@ -22,7 +22,4 @@ nodepool_gearman_servers:
     port: 4730
 
 zuul_statsd_enable: no
-zuul_connections:
-  github:
-    driver: github
 zuul_gearman_server: zuul.vagrant


### PR DESCRIPTION
The zuul_connections variable was moved from production to all, but the other
environments still had stale variables shadowing the all variable.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>