### PR TITLE
Remove the default welcome page

### DIFF
--- a/roles/apache/tasks/apache.yml
+++ b/roles/apache/tasks/apache.yml
@@ -37,6 +37,11 @@
     group: root
   notify: restart apache
 
+- name: Remove ubuntu's default welcome page
+  file:
+    path: /var/www/html/index.html
+    state: absent
+
 - name: set-up ssl if any vhosts require it
   include: ssl.yml
   when:  "{{ apache_vhosts | selectattr('ssl', 'defined') | map(attribute='ssl') | sum }}"


### PR DESCRIPTION
Apache on ubuntu ships with a webroot preconfigured and an index.html
ready to go. This obviously is treated with higher priority than index
files provided by the vhost. Remove the ubuntu one so our vhost's shine
through.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>