### PR TITLE
Don't use /bin/sh in nodepool systemd units

### DIFF
--- a/roles/nodepool/defaults/main.yml
+++ b/roles/nodepool/defaults/main.yml
@@ -1,7 +1,4 @@
 ---
-nodepool_source_dir: /opt/source/nodepool
-nodepool_venv_dir: /opt/venvs/nodepool
-
 nodepool_git_version: master
 
 nodepool_mysql_host: localhost

--- a/roles/nodepool/tasks/main.yml
+++ b/roles/nodepool/tasks/main.yml
@@ -131,7 +131,7 @@
     - Restart nodepool
 
 - name: Install systemd unit files
-  copy:
+  template:
     src: "etc/systemd/system/{{ item }}.service"
     dest: "/etc/systemd/system/{{ item }}.service"
     owner: root

--- a/roles/nodepool/templates/etc/default/nodepool
+++ b/roles/nodepool/templates/etc/default/nodepool
@@ -5,6 +5,5 @@ STATSD_HOST={{ nodepool_statsd_host }}
 STATSD_PORT={{ nodepool_statsd_port }}
 {% endif %}
 
-PREFIX={{ nodepool_venv_path }}
 VIRTUAL_ENV={{ nodepool_venv_path }}
 PATH={{ nodepool_venv_path }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/roles/nodepool/templates/etc/default/nodepool
+++ b/roles/nodepool/templates/etc/default/nodepool
@@ -5,6 +5,6 @@ STATSD_HOST={{ nodepool_statsd_host }}
 STATSD_PORT={{ nodepool_statsd_port }}
 {% endif %}
 
-PREFIX={{ nodepool_venv_dir }}
-VIRTUAL_ENV={{ nodepool_venv_dir }}
-PATH={{ nodepool_venv_dir }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+PREFIX={{ nodepool_venv_path }}
+VIRTUAL_ENV={{ nodepool_venv_path }}
+PATH={{ nodepool_venv_path }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/roles/nodepool/templates/etc/systemd/system/nodepool-builder.service
+++ b/roles/nodepool/templates/etc/systemd/system/nodepool-builder.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=nodepoold Service
+Description=nodepool-builder Service
 After=syslog.target network.target
 
 [Service]
@@ -7,7 +7,7 @@ Type=simple
 User=nodepool
 Group=nodepool
 EnvironmentFile=-/etc/default/nodepool
-ExecStart=/bin/sh -c "${PREFIX}/bin/nodepoold -d --no-deletes --no-webapp -l /etc/nodepool/nodepool-launcher_logging.conf"
+ExecStart={{ nodepool_venv_path }}/bin/nodepool-builder -d -l /etc/nodepool/nodepool-builder_logging.conf
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/nodepool/templates/etc/systemd/system/nodepool-deleter.service
+++ b/roles/nodepool/templates/etc/systemd/system/nodepool-deleter.service
@@ -7,7 +7,7 @@ Type=simple
 User=nodepool
 Group=nodepool
 EnvironmentFile=-/etc/default/nodepool
-ExecStart=/bin/sh -c "${PREFIX}/bin/nodepoold -d --no-launches --no-webapp -l /etc/nodepool/nodepool-deleter_logging.conf"
+ExecStart={{ nodepool_venv_path }}/bin/nodepoold -d --no-launches --no-webapp -l /etc/nodepool/nodepool-deleter_logging.conf
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/nodepool/templates/etc/systemd/system/nodepool-launcher.service
+++ b/roles/nodepool/templates/etc/systemd/system/nodepool-launcher.service
@@ -7,7 +7,7 @@ Type=simple
 User=nodepool
 Group=nodepool
 EnvironmentFile=-/etc/default/nodepool
-ExecStart=/bin/sh -c "${PREFIX}/bin/nodepoold -d --no-deletes --no-launches -l /etc/nodepool/nodepoold_logging.conf"
+ExecStart={{ nodepool_venv_path }}/bin/nodepoold -d --no-deletes --no-webapp -l /etc/nodepool/nodepool-launcher_logging.conf
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/nodepool/templates/etc/systemd/system/nodepoold.service
+++ b/roles/nodepool/templates/etc/systemd/system/nodepoold.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=nodepool-builder Service
+Description=nodepoold Service
 After=syslog.target network.target
 
 [Service]
@@ -7,7 +7,7 @@ Type=simple
 User=nodepool
 Group=nodepool
 EnvironmentFile=-/etc/default/nodepool
-ExecStart=/bin/sh -c "${PREFIX}/bin/nodepool-builder -d -l /etc/nodepool/nodepool-builder_logging.conf"
+ExecStart={{ nodepool_venv_path }}/bin/nodepoold -d --no-deletes --no-launches -l /etc/nodepool/nodepoold_logging.conf
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/python-app/tasks/main.yml
+++ b/roles/python-app/tasks/main.yml
@@ -41,3 +41,8 @@
     name: "{{ python_app_source_path }}/{{ name }}"
     virtualenv: "{{ python_app_venv_path }}/{{ name }}"
   when: python_app_git_checkout.changed
+
+- name: Set python-app facts
+  set_fact: >
+    {{ name | replace('-', '_') }}_venv_path={{ python_app_venv_path }}/{{ name }}
+    {{ name | replace('-', '_') }}_source_path={{ python_app_source_path }}/{{ name }}

--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -1,6 +1,5 @@
 zuul_git_repo_url: https://github.com/BonnyCI/zuul
 zuul_git_branch: github-integration
-zuul_venv_dir: /opt/venvs/zuul
 zuul_allow_restart_services: no
 
 zuul_gearman_server: 127.0.0.1

--- a/roles/zuul/templates/etc/default/zuul
+++ b/roles/zuul/templates/etc/default/zuul
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 
-PATH={{ zuul_venv_dir }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+PATH={{ zuul_venv_path }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 {% if zuul_statsd_enable %}
 STATSD_HOST={{ zuul_statsd_host }}
 STATSD_PORT={{ zuul_statsd_port }}

--- a/roles/zuul/templates/etc/systemd/system/zuul.service
+++ b/roles/zuul/templates/etc/systemd/system/zuul.service
@@ -8,7 +8,7 @@ User=zuul
 Group=zuul
 LimitNOFILE=8192
 EnvironmentFile=-/etc/default/{{ item }}
-ExecStart={{ zuul_venv_dir }}/bin/{{ item }} -d
+ExecStart={{ zuul_venv_path }}/bin/{{ item }} -d
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]


### PR DESCRIPTION
Use the python-app role to set the nodepool_venv_path instead of customizing
that manually.

Then use that nodepool_venv_path to launch the process from the unit file so
that systemctl restart works correctly.