### PR TITLE
Add a restart playbook

### DIFF
--- a/restart.yml
+++ b/restart.yml
@@ -1,0 +1,57 @@
+---
+- name: Restart zuul services
+  hosts: zuul
+  become: yes
+  tags:
+    - zuul
+    - zuul-server
+    - zuul-launcher
+  tasks:
+    - name: restart zuul-server
+      service:
+        name: zuul-server
+        state: restarted
+
+    - name: wait for zuul to start (check for gearman)
+      wait_for:
+        port: "{{ zuul_gearman_port | default(4730) }}"
+        timeout: 300
+        delay: 2
+
+    - name: restart zuul-launcher
+      service:
+        name: zuul-launcher
+        state: restarted
+
+- name: Restart zuul mergers
+  hosts: mergers
+  tags:
+    - zuul
+    - zuul-merger
+  tasks:
+    - name: restart zuul-merger
+      service:
+        name: zuul-merger
+        state: restarted
+      with_items:
+        - zuul-merger
+
+- name: Restart nodepool services
+  hosts: nodepool
+  become: yes
+  tags:
+    - nodepool
+  tasks:
+    - name: Restart nodepoold
+      service:
+        name: nodepoold
+        state: restarted
+
+    - name: Restart other nodepool services
+      service:
+        name: "{{ item }}"
+        state: restarted
+      with_items:
+        - nodepool-builder
+        - nodepool-deleter
+        - nodepool-launcher


### PR DESCRIPTION
Add a playbook that will restart the entire zuul world. This hasn't been
tested in production, but I think it's a good idea to start and improve
it as we go.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>