### PR TITLE
Add apache rewrite rule to also proxy webhooks

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -50,8 +50,8 @@
         - monitoring
 
     - role: apache
-      apache_mods_enabled: "{{ bonnyci_zuul_status_apache_mods_enabled }}"
-      apache_vhosts: "{{ bonnyci_zuul_status_apache_vhosts }}"
+      apache_mods_enabled: "{{ bonnyci_zuul_webapp_apache_mods_enabled }}"
+      apache_vhosts: "{{ bonnyci_zuul_webapp_apache_vhosts }}"
 
     - role: dd-apache
       tags:

--- a/inventory/group_vars/multinode
+++ b/inventory/group_vars/multinode
@@ -4,7 +4,7 @@ bastion_clouds:
   - bastioncloud
 
 bonnyci_logs_apache_server_name: logs.multinode
-bonnyci_zuul_status_apache_server_name: zuul.multinode
+bonnyci_zuul_webapp_apache_server_name: zuul.multinode
 
 datadog_enabled: no
 

--- a/inventory/group_vars/production
+++ b/inventory/group_vars/production
@@ -2,7 +2,7 @@ bastion_clouds:
   - contra-sjc
 
 bonnyci_logs_apache_server_name: logs.bonnyci.com
-bonnyci_zuul_status_apache_server_name: zuul.bonnyci.portbleu.com
+bonnyci_zuul_webapp_apache_server_name: zuul.bonnyci.portbleu.com
 bonnyci_zuul_merger_apache_server_name: merger01.bonnyci-internal.portbleu.com
 
 nodepool_gearman_servers:

--- a/inventory/group_vars/vagrant
+++ b/inventory/group_vars/vagrant
@@ -2,7 +2,7 @@ bastion_clouds:
   - bastioncloud
 
 bonnyci_zuul_merger_apache_server_name: merger.vagrant
-bonnyci_zuul_status_apache_server_name: zuul.vagrant
+bonnyci_zuul_webapp_apache_server_name: zuul.vagrant
 
 datadog_enabled: no
 

--- a/inventory/group_vars/zuul
+++ b/inventory/group_vars/zuul
@@ -1,16 +1,19 @@
-bonnyci_zuul_status_apache_mods_enabled:
+bonnyci_zuul_webapp_apache_mods_enabled:
   - proxy.load
   - proxy_http.load
   - rewrite.load
 
-bonnyci_zuul_status_apache_vhosts:
+bonnyci_zuul_webapp_apache_vhosts:
   - name: status
-    server_name: "{{ bonnyci_zuul_status_apache_server_name | default('zuul') }}"
+    delete: true
+  - name: webapp
+    server_name: "{{ bonnyci_zuul_webapp_apache_server_name | default('zuul') }}"
     document_root: /opt/source/zuul/etc/status/public_html/
     vhost_extra: |
       RewriteEngine on
       RewriteRule ^/status.json$ http://127.0.0.1:8001/status.json [P]
       RewriteRule ^/status/(.*) http://127.0.0.1:8001/status/$1 [P]
+      RewriteRule ^/connection/github/payload$ http://127.0.0.1:8001/connection/github/payload [P]
 
 zuul_components:
   - zuul-launcher


### PR DESCRIPTION
This updates the apache vhost config on the zuul host to also proxy github
webhooks to the local webapp.  Since our vhost is now doing more than just
serving status data I've updated variable and vhost names.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>