### PR TITLE
Fix gate trigger requirement

### DIFF
--- a/roles/zuul/templates/etc/zuul/config/layout.yaml
+++ b/roles/zuul/templates/etc/zuul/config/layout.yaml
@@ -38,7 +38,7 @@ pipelines:
         - event: status
           status: "anne-bonny:check_github:success"
         - event: pr-review
-          state: 'approve'
+          state: 'approved'
         - event: pr-comment
           comment: (?i)^\s*gate-recheck\s*$
     require:


### PR DESCRIPTION
The github payload is being sent with `"state": "approved"`, so update
the trigger to require this state.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>