### PR TITLE
Make it possible to use custom secrets in vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,18 +43,21 @@ Vagrant.configure(2) do |config|
       apt-get -y install build-essential python python-dev libffi-dev libssl-dev
       pip install ansible
 
-      # Move the example secrets file in place
+      # If there's no secrets.yml in the working directory, use the example file
+      if ! test -f /vagrant/secrets.yml ; then
+        cp /vagrant/secrets.yml.example /vagrant/secrets.yml
+      fi
+
+      # Create a symlink pointing at the live secrets.yml
       if test -f /etc/secrets.yml ; then
         rm /etc/secrets.yml
       fi
-      cp /vagrant/secrets.yml.example /etc/secrets.yml
+      ln -s /vagrant/secrets.yml /etc/secrets.yml
 
       # disable cron runs, run ansible manually while testing
       touch /etc/disable-ansible-runner-cideploy
       touch /etc/disable-ansible-runner-system-ansible
     SHELL
-
-    bastion.vm.provision "shell", inline: "ansible-galaxy install --roles-path /vagrant/upstream_roles -r /vagrant/requirements.yml"
 
     bastion.vm.provision "ansible_local" do |ansible|
       ansible.inventory_path = "/vagrant/inventory/vagrant"

--- a/tools/vagrant-run-ansible.sh
+++ b/tools/vagrant-run-ansible.sh
@@ -2,4 +2,4 @@
 
 export ANSIBLE_CONFIG=/vagrant/ansible.cfg
 export ANSIBLE_INVENTORY=/vagrant/inventory/vagrant
-ansible-playbook -v -e @/etc/secrets.yml --skip-tags monitoring /vagrant/install-ci.yml "$@"
+ansible-playbook -v -e @/vagrant/secrets.yml --skip-tags monitoring /vagrant/install-ci.yml "$@"


### PR DESCRIPTION
Make the example secrets a fallback for the vagrant environment,
rather than a source of testing truth.

Also, stop trying to install roles from galaxy based on requirements.yml,
that file doesn't exist.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>