### PR TITLE
Use the public interface for the zuul webapp.

### DIFF
--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -10,6 +10,8 @@ zuul_git_user_name: Anne Bonny
 zuul_merger_apache_port: 8858
 zuul_merger_url: "http://{{ inventory_hostname }}:{{ zuul_merger_apache_port }}/p"
 
+zuul_webapp_listen_address: 0.0.0.0
+
 zuul_connections:
   github:
     driver: github


### PR DESCRIPTION
Unfortunately the github webhook handler listens on the same applciation
as the status application. By making this listen on localhost we cut off
webhook delivery.

We should fix this in zuul, however for now just open up the interface
again.

Fixes: BonnyCI/projman#117