### PR TITLE
Create a letsencrypt role and set up webhook certs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ matrix:
 
 env:
   - TEST_RUN="ansible-playbook -i herp, bastion.yml install-ci.yml provision.yml tests/validate-ci.yml --syntax-check"
-  - TEST_RUN="ansible-playbook -i inventory/allinone bastion.yml install-ci.yml tests/validate-ci.yml -c docker -vv -e @secrets.yml.example --skip-tags monitoring,no-docker"
-  - TEST_RUN="ansible-playbook -i inventory/allinone install-ci.yml tests/validate-ci.yml -c docker -vv -e @secrets.yml.example --skip-tags monitoring,no-docker"
+  - TEST_RUN="ansible-playbook -i inventory/allinone bastion.yml install-ci.yml tests/validate-ci.yml -c docker -vv -e @secrets.yml.example --skip-tags monitoring,no-docker,letsencrypt"
+  - TEST_RUN="ansible-playbook -i inventory/allinone install-ci.yml tests/validate-ci.yml -c docker -vv -e @secrets.yml.example --skip-tags monitoring,no-docker,letsencrypt"
 
 before_install:
 - docker pull ubuntu:xenial

--- a/install-ci.yml
+++ b/install-ci.yml
@@ -5,9 +5,16 @@
   tags: ['common']
   roles:
     - role: common
+
     - role: dd-agent
       tags:
         - monitoring
+
+    - role: letsencrypt
+      tags:
+        - letsencrypt
+      when:
+        - letsencrypt_csr_cn | default(False)
 
 - name: Install mysql
   hosts: mysql

--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -1,4 +1,15 @@
+apache_ssl_use_stapling: yes
+
 hoist_repo: https://github.com/BonnyCI/hoist.git
+
+letsencrypt_account_key_content: "{{ secrets.letsencrypt.account_key }}"
+letsencrypt_csr_dn:
+  C: AU
+  ST: NSW
+  L: Australia
+  O: BonnyCI
+letsencrypt_configure_redirect: yes
+letsencrypt_email: jamielennox@gmail.com
 
 zuul_gearman_server_listen_address: 0.0.0.0
 zuul_gearman_server_start: true

--- a/inventory/group_vars/production
+++ b/inventory/group_vars/production
@@ -5,6 +5,8 @@ bonnyci_logs_apache_server_name: logs.bonnyci.com
 bonnyci_zuul_webapp_apache_server_name: zuul.bonnyci.portbleu.com
 bonnyci_zuul_merger_apache_server_name: merger01.bonnyci-internal.portbleu.com
 
+letsencrypt_production: yes
+
 nodepool_gearman_servers:
   - host: zuul.bonnyci-internal.portbleu.com
     port: 4730

--- a/inventory/group_vars/zuul
+++ b/inventory/group_vars/zuul
@@ -3,12 +3,21 @@ bonnyci_zuul_webapp_apache_mods_enabled:
   - proxy_http.load
   - rewrite.load
 
+letsencrypt_key_path: /etc/apache2/cert/ansible.key
+letsencrypt_cert_path: /etc/apache2/cert/ansible.crt
+letsencrypt_chain_path: /etc/letsencrypt/chain.pem
+
 bonnyci_zuul_webapp_apache_vhosts:
   - name: status
     delete: true
+
   - name: webapp
     server_name: "{{ bonnyci_zuul_webapp_apache_server_name | default('zuul') }}"
     document_root: /opt/source/zuul/etc/status/public_html/
+    ssl: "{{ bonnyci_zuul_webapp_ssl | default(False) }}"
+    certificate_file: "{{ letsencrypt_cert_path | default('') }}"
+    certificate_key_file: "{{ letsencrypt_key_path | default('') }}"
+    certificate_chain_file: "{{ letsencrypt_chain_path | default('') }}"
     vhost_extra: |
       RewriteEngine on
       RewriteRule ^/status.json$ http://127.0.0.1:8001/status.json [P]
@@ -18,4 +27,3 @@ bonnyci_zuul_webapp_apache_vhosts:
 zuul_components:
   - zuul-launcher
   - zuul-server
-

--- a/inventory/host_vars/zuul.bonnyci-internal.portbleu.com
+++ b/inventory/host_vars/zuul.bonnyci-internal.portbleu.com
@@ -1,0 +1,3 @@
+---
+letsencrypt_csr_cn: zuul.bonnyci.com
+bonnyci_zuul_webapp_ssl: yes

--- a/roles/dd-zuul/defaults/main.yml
+++ b/roles/dd-zuul/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
-dd_zuul_status_url: http://localhost:8001/status.json
+dd_zuul_status_port: 8001
+dd_zuul_status_url: "http://localhost:{{ dd_zuul_status_port }}/status.json"

--- a/roles/letsencrypt/defaults/main.yml
+++ b/roles/letsencrypt/defaults/main.yml
@@ -1,0 +1,47 @@
+---
+letsencrypt_webroot: /var/www/html/letsencrypt
+
+letsencrypt_production: no
+letsencrypt_acme_directory: "{{ letsencrypt_production | ternary(letsencrypt_production_api, letsencrypt_staging_api) }}"
+letsencrypt_email:
+letsencrypt_remaining_days: 10
+
+letsencrypt_name: ansible
+letsencrypt_data_dir: /etc/apache2/cert
+
+letsencrypt_cert_path: "{{ letsencrypt_data_dir }}/{{ letsencrypt_name }}.crt"
+
+letsencrypt_chain_path: "/etc/letsencrypt/chain.pem"
+letsencrypt_chain_url: "https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem"
+letsencrypt_chain_owner: root
+letsencrypt_chain_mode: 0644
+
+letsencrypt_csr_config_path: "{{ letsencrypt_data_dir }}/{{ letsencrypt_name }}-openssl.conf"
+letsencrypt_csr_path: "{{ letsencrypt_data_dir }}/{{ letsencrypt_name }}.csr"
+letsencrypt_csr_owner: root
+letsencrypt_csr_mode: 0644
+
+letsencrypt_key_path: "{{ letsencrypt_data_dir }}/{{ letsencrypt_name }}.key"
+letsencrypt_key_owner: www-data
+letsencrypt_key_mode: 0600
+
+letsencrypt_configure_redirect: no
+
+letsencrypt_account_key_path: /etc/letsencrypt/account.key
+letsencrypt_account_key_owner: root
+letsencrypt_account_key_mode: 0400
+
+letsencrypt_csr_key_bits: 2048
+letsencrypt_csr_dn:
+  C: AU
+  ST: NSW
+  L: Australia
+
+letsencrypt_csr_country_code: AU
+letsencrypt_csr_state_code: NSW
+letsencrypt_csr_alt_names: {}
+
+letsencrypt_csr_key_usage: nonRepudiation, digitalSignature, keyEncipherment
+letsencrypt_csr_extended_key_usage: serverAuth
+
+letsencrypt_vhost_extra: ""

--- a/roles/letsencrypt/meta/main.yml
+++ b/roles/letsencrypt/meta/main.yml
@@ -1,0 +1,21 @@
+dependencies:
+  - role: apache
+    ssl: no
+
+    apache_mods_enabled:
+      - rewrite.load
+
+    apache_vhosts:
+      - name: letsencrypt
+        document_root: "{{ letsencrypt_webroot }}"
+        port: 80
+        admin: "{{ letsencrypt_email }}"
+
+        vhost_extra: |
+          {{ letsencrypt_vhost_extra }}
+          {% if letsencrypt_configure_redirect %}
+          RewriteEngine On
+          RewriteCond %{HTTPS} off
+          RewriteCond %{REQUEST_URI} !^/.well-known/
+          RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=302,L,QSA]
+          {% endif %}

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -1,0 +1,117 @@
+---
+- name: Install openssl
+  apt:
+    name: openssl
+    state: present
+
+- name: create webroot folder
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - "{{ letsencrypt_webroot }}/.well-known/acme-challenge"
+    - "{{ letsencrypt_account_key_path | dirname }}"
+    - "{{ letsencrypt_csr_path | dirname }}"
+    - "{{ letsencrypt_csr_config_path | dirname }}"
+    - "{{ letsencrypt_cert_path | dirname }}"
+    - "{{ letsencrypt_key_path | dirname }}"
+    - "{{ letsencrypt_cert_path | dirname }}"
+    - "{{ letsencrypt_chain_path | dirname }}"
+
+- name: Create CSR configuration
+  template:
+    src: openssl-req.conf
+    dest: "{{ letsencrypt_csr_config_path }}"
+    mode: "{{ letsencrypt_csr_mode }}"
+    owner: "{{ letsencrypt_csr_owner }}"
+  register: letsencrypt_create_csr
+
+- name: Check key exists
+  stat:
+    path: "{{ item }}"
+  register: letsencrypt_stat
+  with_items:
+    - "{{ letsencrypt_key_path }}"
+    - "{{ letsencrypt_csr_path }}"
+
+- name: Create CSR
+  command: >
+    openssl req -new -nodes -batch
+    -config {{ letsencrypt_csr_config_path }}
+    -out {{ letsencrypt_csr_path }}
+    {% if letsencrypt_stat.results.0.stat.exists %}
+    -key {{ letsencrypt_key_path }}
+    {% else %}
+    -keyout {{ letsencrypt_key_path }}
+    {% endif %}
+  register: letsencrypt_create_csr_command
+  failed_when: '"error" in letsencrypt_create_csr_command.stderr.lower()'
+  when: (not letsencrypt_stat.results.0.stat.exists) or
+        (not letsencrypt_stat.results.1.stat.exists) or
+        (letsencrypt_create_csr.changed | default(False))
+
+- name: set key owner
+  file:
+    path: "{{ letsencrypt_key_path }}"
+    mode: "{{ letsencrypt_key_mode }}"
+    owner: "{{ letsencrypt_key_owner }}"
+
+- name: Copy account key to destination
+  copy:
+    dest: "{{ letsencrypt_account_key_path }}"
+    content: "{{ letsencrypt_account_key_content }}"
+    mode: "{{ letsencrypt_account_key_mode }}"
+    owner: "{{ letsencrypt_account_key_owner }}"
+  when: letsencrypt_account_key_content is defined
+
+- name: set account key properties
+  file:
+    path: "{{ letsencrypt_account_key_path }}"
+    mode: "{{ letsencrypt_account_key_mode }}"
+    owner: "{{ letsencrypt_account_key_owner }}"
+  when: letsencrypt_account_key_content is not defined
+
+- name: Download certificate chain
+  get_url:
+    url: "{{ letsencrypt_chain_url }}"
+    dest: "{{ letsencrypt_chain_path }}"
+    owner: "{{ letsencrypt_chain_owner }}"
+    mode: "{{ letsencrypt_chain_mode }}"
+
+- name: Check for letsencrypt changes
+  letsencrypt:
+    account_email: "{{ letsencrypt_email }}"
+    account_key: "{{ letsencrypt_account_key_path }}"
+    acme_directory: "{{ letsencrypt_acme_directory }}"
+    challenge: "http-01"
+    csr: "{{ letsencrypt_csr_path }}"
+    dest: "{{ letsencrypt_cert_path }}"
+    remaining_days: "{{ letsencrypt_remaining_days }}"
+  register: letsencrypt_challenge_response
+
+- name: Install letsencrypt challenges
+  copy:
+    dest: "{{ letsencrypt_webroot }}/{{ item.value['http-01']['resource'] }}"
+    content: "{{ item.value['http-01']['resource_value'] }}"
+  with_dict: "{{ letsencrypt_challenge_response['challenge_data'] | default({}) }}"
+  when: letsencrypt_challenge_response.changed
+
+- name: Update letsencrypt certificates
+  letsencrypt:
+    account_email: "{{ letsencrypt_email }}"
+    account_key: "{{ letsencrypt_account_key_path }}"
+    acme_directory: "{{ letsencrypt_acme_directory }}"
+    challenge: "http-01"
+    csr: "{{ letsencrypt_csr_path }}"
+    data: "{{ letsencrypt_challenge_response }}"
+    dest: "{{ letsencrypt_cert_path }}"
+    remaining_days: "{{ letsencrypt_remaining_days }}"
+  notify: restart apache
+  when: letsencrypt_challenge_response.changed
+
+- name: Cleanup letsencrypt challenges
+  file:
+    path: "{{ letsencrypt_webroot }}/{{ item.value['http-01']['resource'] }}"
+    state: absent
+  with_dict: "{{ letsencrypt_challenge_response['challenge_data'] | default({}) }}"
+  when: letsencrypt_challenge_response.changed

--- a/roles/letsencrypt/templates/openssl-req.conf
+++ b/roles/letsencrypt/templates/openssl-req.conf
@@ -1,0 +1,24 @@
+[req]
+default_bits = {{ letsencrypt_csr_key_bits }}
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+prompt = no
+
+[req_distinguished_name]
+{% for k, v in letsencrypt_csr_dn.items() %}
+{{ k }} = {{ v }}
+{% endfor %}
+CN = {{ letsencrypt_csr_cn | mandatory }}
+
+[v3_req]
+basicConstraints = CA:FALSE
+keyUsage = {{ letsencrypt_csr_key_usage }}
+extendedKeyUsage = {{ letsencrypt_csr_extended_key_usage }}
+{% if letsencrypt_csr_alt_names %}
+subjectAltName = @alt_names
+
+[alt_names]
+{% for name in letsencrypt_csr_alt_names %}
+DNS.{{ loop.index }} = {{ name }}
+{% endfor %}
+{% endif %}

--- a/roles/letsencrypt/vars/main.yml
+++ b/roles/letsencrypt/vars/main.yml
@@ -1,0 +1,2 @@
+letsencrypt_production_api: "https://acme-v01.api.letsencrypt.org/directory"
+letsencrypt_staging_api: "https://acme-staging.api.letsencrypt.org/directory"

--- a/secrets.yml.example
+++ b/secrets.yml.example
@@ -63,3 +63,8 @@ secrets:
         -----END RSA PRIVATE KEY-----
       public: >
         ssh-rsa a public ssh key goes here zuul@zuul
+  letsencrypt:
+    account_key: |
+      -----BEGIN RSA PRIVATE KEY-----
+      ThisIsNotARealKey
+      -----END RSA PRIVATE KEY-----

--- a/tests/test-hoist-ansible.sh
+++ b/tests/test-hoist-ansible.sh
@@ -4,5 +4,5 @@ echo "Running hoist ansible syntax test"
 ansible-playbook -i /dev/null --syntax-check $(find . tests -maxdepth 1 -type f -name \*.yml -not -name .travis.yml)
 
 echo "Running hoist ansible deployment test"
-ansible-playbook -i inventory/nodepool.py install-ci.yml --skip-tags monitoring -e @secrets.yml.example
+ansible-playbook -i inventory/nodepool.py install-ci.yml --skip-tags monitoring,letsencrypt -e @secrets.yml.example
 ansible-playbook -i inventory/nodepool.py tests/validate-ci.yml


### PR DESCRIPTION
Create a role that can do letsencrypt certificate fetching and renewal
and set up the zuul server to proxy requests to the github webhook port
so github can do secure requests.

This is on the same port as the status.json which we might want to have
a look at.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>