### PR TITLE
Use bonnyci.org for letsencrypt

### DIFF
--- a/inventory/host_vars/zuul.bonnyci-internal.portbleu.com
+++ b/inventory/host_vars/zuul.bonnyci-internal.portbleu.com
@@ -1,3 +1,3 @@
 ---
-letsencrypt_csr_cn: zuul.bonnyci.com
+letsencrypt_csr_cn: zuul.bonnyci.org
 bonnyci_zuul_webapp_ssl: yes


### PR DESCRIPTION
Ooops, we don't have zuul.bonnyci.com set up, we definitely should use
.org here.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>