### PR TITLE
Fix failed_when on service module

### DIFF
--- a/roles/zuul/tasks/main.yml
+++ b/roles/zuul/tasks/main.yml
@@ -93,7 +93,9 @@
     - zuul-merger
     - zuul-server
   register: stop_zuul
-  failed_when: "stop_zuul.rc != 0 and not 'service not loaded' in stop_zuul.stderr"
+  failed_when:
+    - stop_zuul|failed
+    - "'Could not find the requested service' not in stop_zuul.msg"
 
 - meta: flush_handlers
 


### PR DESCRIPTION
The service action plugin, which in our case redirects to the systemd
module, does not return an rc or stderr, that's from the command module.
Instead, we need to handle what the systemd module gives us, which is
basically a msg and a failed state.

Signed-off-by: Jesse Keating <jkeating@j2solutions.net>