### PR TITLE
Add https security group to zuul

### DIFF
--- a/create-hosts.yml
+++ b/create-hosts.yml
@@ -33,6 +33,8 @@
       servers:
         - name: zuul
           public_address: 169.45.113.36
+          security_groups:
+            - https
         - name: nodepool
         - name: logs
           public_address: 169.45.113.51


### PR DESCRIPTION
The zuul production server will also need the https security group for
status pages and web hooks. Going to do this manually for now as this is
not run automatically but we should fix that in future.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>