### PR TITLE
Enable filebeat output to logstash everywhere

### DIFF
--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -2,6 +2,8 @@ apache_ssl_use_stapling: yes
 
 hoist_repo: https://github.com/BonnyCI/hoist.git
 
+filebeat_output_logstash_enabled: true
+
 letsencrypt_account_key_content: "{{ secrets.letsencrypt.account_key }}"
 letsencrypt_csr_dn:
   C: AU

--- a/inventory/group_vars/monitoring
+++ b/inventory/group_vars/monitoring
@@ -1,3 +1,1 @@
 elasticsearch_cluster_name: bonnyci
-
-filebeat_output_logstash_enabled: true


### PR DESCRIPTION
We currently only enable filebeat output to logstash on the monitoring host,
but only install filebeat on the nodepool and zuul hosts. Enable filebeat
output to logstash on all hosts so that nodepool and zuul will begin sending
data to logstash on the monitoring host.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>