### PR TITLE
Add shellcheck to bonnyci standard image

### DIFF
--- a/roles/nodepool/files/etc/nodepool/elements/bonnyci-nodepool/package-installs.yaml
+++ b/roles/nodepool/files/etc/nodepool/elements/bonnyci-nodepool/package-installs.yaml
@@ -4,3 +4,4 @@ python-dev:
 python3-dev:
 libssl-dev:
 libffi-dev:
+shellcheck:


### PR DESCRIPTION
We use it in two of our own tests, and it seems worth it to simply have
it available for everyone.

Signed-off-by: Clint Byrum <clint@fewbar.com>