### PR TITLE
Allow specifying integration id and keys to zuul

### DIFF
--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -21,7 +21,11 @@ zuul_git_user_name: Anne Bonny
 zuul_merger_apache_port: 8858
 zuul_merger_url: "http://{{ inventory_hostname }}:{{ zuul_merger_apache_port }}/p"
 
+zuul_github_integration_key_file: /etc/zuul/integration.key
+
 zuul_connections:
   github:
     driver: github
-    api_token: "{{ secrets.zuul_github_api_key }}"
+    api_token: "{{ secrets.zuul_github_api_key | default('') }}"
+    integration_id: "{{ secrets.zuul_github_integration_id | default('') }}"
+    integration_key: "{{ zuul_github_integration_key_file }}"

--- a/roles/zuul/tasks/main.yml
+++ b/roles/zuul/tasks/main.yml
@@ -47,6 +47,15 @@
     group: zuul
     mode: 0644
 
+- name: Install zuul integration key
+  copy:
+    dest: /etc/zuul/integration.key
+    content: "{{ secrets.zuul_github_integration_key_content }}"
+    owner: zuul
+    group: zuul
+    mode: 0400
+  when: secrets.zuul_github_integration_key_content is defined
+
 - name: Install zuul config
   template:
     src: etc/zuul/zuul.conf

--- a/roles/zuul/templates/etc/zuul/zuul.conf
+++ b/roles/zuul/templates/etc/zuul/zuul.conf
@@ -12,7 +12,9 @@ start = {{ zuul_gearman_server_start }}
 {% for name, details in zuul_connections.items() %}
 [connection {{ name }}]
 {% for key, value in details.items() %}
+{% if value %}
 {{ key }} = {{ value }}
+{% endif %}
 {% endfor %}
 
 {% endfor %}


### PR DESCRIPTION
When using zuul as an integration you need to specify the integration id
and the private key to zuul. Plumb these config variables into hoist.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>