### PR TITLE
Turn on logstash output from filebeat

### DIFF
--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -1,5 +1,7 @@
 apache_ssl_use_stapling: yes
 
+filebeat_output_logstash_enabled: true
+
 hoist_repo: https://github.com/BonnyCI/hoist.git
 
 letsencrypt_account_key_content: "{{ secrets.letsencrypt.account_key }}"

--- a/inventory/group_vars/monitoring
+++ b/inventory/group_vars/monitoring
@@ -1,3 +1,1 @@
 elasticsearch_cluster_name: bonnyci
-
-filebeat_output_logstash_enabled: true


### PR DESCRIPTION
There is a default off for outputing filebeat data for logstash meaning
that there is no output configured for the logstash listeners. This
needs to be enabled for the hosts running the filebeat, not the
monitoring hosts which are running logstash itself.

Enable logstash output everywhere as it's setup by default in hoist.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>