### PR TITLE
Fix dd-builder logging in cronjob to use sh syntax

### DIFF
--- a/roles/datadog-builder/tasks/datadog-builder.yml
+++ b/roles/datadog-builder/tasks/datadog-builder.yml
@@ -57,4 +57,4 @@
       /opt/venvs/datadog-builder/bin/datadog-builder
       --config /etc/datadog-builder/datadog-secrets.yml
       update {{ datadog_builder_monitor_dir }}/{{ datadog_builder_monitor_file }}
-      &>> /var/log/datadog-builder/datadog-builder.log
+      2>&1 >> /var/log/datadog-builder/datadog-builder.log


### PR DESCRIPTION
Mistakenly used bash syntax, which doesn't work...

Signed-off-by: Bradon Kanyid <rattboi@gmail.com>