### PR TITLE
Fix the dd-builder logging (yes, again)

### DIFF
--- a/roles/datadog-builder/tasks/datadog-builder.yml
+++ b/roles/datadog-builder/tasks/datadog-builder.yml
@@ -57,4 +57,4 @@
       /opt/venvs/datadog-builder/bin/datadog-builder
       --config /etc/datadog-builder/datadog-secrets.yml
       update {{ datadog_builder_monitor_dir }}/{{ datadog_builder_monitor_file }}
-      2>&1 >> /var/log/datadog-builder/datadog-builder.log
+      >> /var/log/datadog-builder/datadog-builder.log 2>&1


### PR DESCRIPTION
My brain can't process order of operations, apparently. Gotta redirect
stderr to the stdout file descriptor AFTER it's already redirected to a
file.

Signed-off-by: Bradon Kanyid <rattboi@gmail.com>