### PR TITLE
Add datadog-logging to zuul and nodepool

### DIFF
--- a/inventory/group_vars/production
+++ b/inventory/group_vars/production
@@ -45,7 +45,9 @@ nodepool_providers:
         user-home: /home/bonnyci
         username: bonnyci
 nodepool_statsd_enable: yes
+nodepool_use_datadog_logging: yes
 nodepool_zmq_publishers:
   - tcp://zuul.bonnyci-internal.portbleu.com:8888
 
 zuul_gearman_server: zuul.bonnyci-internal.portbleu.com
+zuul_use_datadog_logging: yes

--- a/roles/nodepool/defaults/main.yml
+++ b/roles/nodepool/defaults/main.yml
@@ -23,6 +23,8 @@ nodepool_gearman_servers:
 nodepool_zmq_publishers:
   - tcp://localhost:8888
 
+nodepool_use_datadog_logging: no
+
 nodepool_diskimages: []
 
 nodepool_labels: []

--- a/roles/nodepool/tasks/main.yml
+++ b/roles/nodepool/tasks/main.yml
@@ -107,6 +107,13 @@
   notify:
     - Restart nodepool builder
 
+- name: Install datadog logging library
+  pip:
+    name: git+https://github.com/BonnyCI/datadog-logging.git#egg=datadog-logging
+    state: latest
+    virtualenv: "{{ nodepool_venv_path }}"
+  when: nodepool_use_datadog_logging
+
 - name: Write logging config
   template:
     src: "etc/nodepool/logging.conf"

--- a/roles/nodepool/templates/etc/nodepool/logging.conf
+++ b/roles/nodepool/templates/etc/nodepool/logging.conf
@@ -2,14 +2,14 @@
 keys=root,nodepool,requests
 
 [handlers]
-keys=console,debug,normal
+keys=console,debug,normal{% if nodepool_use_datadog_logging %},datadog{% endif %}
 
 [formatters]
 keys=simple
 
 [logger_root]
 level=WARNING
-handlers=console
+handlers=console{% if nodepool_use_datadog_logging %},datadog{% endif %}
 
 [logger_requests]
 level=WARNING
@@ -38,6 +38,14 @@ level=INFO
 class=logging.handlers.WatchedFileHandler
 formatter=simple
 args=('/var/log/nodepool/{{ item }}.log',)
+
+{% if nodepool_use_datadog_logging %}
+[handler_datadog]
+level=ERROR
+class=datadog_logging.DatadogLogStatsdHandler
+formatter=simple
+args=()
+{% endif %}
 
 [formatter_simple]
 format=%(asctime)s %(levelname)s %(name)s: %(message)s

--- a/roles/python-app/tasks/main.yml
+++ b/roles/python-app/tasks/main.yml
@@ -33,6 +33,7 @@
     name: "{{ item.name }}"
     version: "{{ item.version | default(omit) }}"
     virtualenv: "{{ python_app_venv_path }}/{{ name }}"
+    state: "{{ item.state | default(omit) }}"
   with_items: "{{ python_app_pipdeps }}"
 
 - name: Install application

--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -23,6 +23,7 @@ zuul_git_user_name: user@domain.io
 zuul_git_user_email: My Name
 
 zuul_connections: {}
+zuul_use_datadog_logging: False
 
 zuul_sites:
   bonnyci-scp:

--- a/roles/zuul/tasks/main.yml
+++ b/roles/zuul/tasks/main.yml
@@ -54,6 +54,13 @@
     owner: zuul
   notify: Restart zuul
 
+- name: Install datadog logging library
+  pip:
+    name: git+https://github.com/BonnyCI/datadog-logging.git#egg=datadog-logging
+    state: latest
+    virtualenv: "{{ zuul_venv_path }}"
+  when: zuul_use_datadog_logging
+
 - name: Install service environment configs
   template:
     src: etc/default/zuul

--- a/roles/zuul/templates/etc/zuul/logging.conf
+++ b/roles/zuul/templates/etc/zuul/logging.conf
@@ -3,14 +3,14 @@
 keys=root,zuul,gerrit,gear
 
 [handlers]
-keys=debug,normal
+keys=debug,normal{% if zuul_use_datadog_logging %},datadog{% endif %}
 
 [formatters]
 keys=simple
 
 [logger_root]
 level=WARNING
-handlers=normal
+handlers=normal{% if zuul_use_datadog_logging %},datadog{% endif %}
 
 [logger_zuul]
 level=DEBUG
@@ -38,6 +38,14 @@ level=WARNING
 class=logging.handlers.WatchedFileHandler
 formatter=simple
 args=('/var/log/zuul/{{ item }}.log',)
+
+{% if zuul_use_datadog_logging %}
+[handler_datadog]
+level=ERROR
+class=datadog_logging.DatadogLogStatsdHandler
+formatter=simple
+args=()
+{% endif %}
 
 [formatter_simple]
 format=%(asctime)s %(levelname)s %(name)s: %(message)s


### PR DESCRIPTION
Add the datadog-logging module to zuul and nodepool to send error
messages to datadog.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>