### PR TITLE
Add logstash security group and add to logs server

### DIFF
--- a/create-hosts.yml
+++ b/create-hosts.yml
@@ -25,11 +25,19 @@
             - protocol: tcp
               port_range_min: 443
               port_range_max: 443
+
+        - name: logstash
+          rules:
+            - protocol: tcp
+              port_range_min: 5044
+              port_range_max: 5044
+
       keys:
         - name: root-contrasjc-bastion
           public_key_file: /root/.ssh/id_rsa.pub
         - name: ci-deploy-contrasjc-bastion
           public_key_file: /home/cideploy/.ssh/id_rsa.pub
+
       servers:
         - name: zuul
           public_address: 169.45.113.36
@@ -42,3 +50,4 @@
             - ssh
             - http
             - https
+            - logstash


### PR DESCRIPTION
Logstash isn't working as the filebeats cannot connect to the logstash
instance to upload their logs.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>