### PR TITLE
Don't hardcode logs.bonnyci.com into zuul

### DIFF
--- a/inventory/group_vars/multinode
+++ b/inventory/group_vars/multinode
@@ -38,4 +38,5 @@ nodepool_zmq_publishers:
   - "tcp://{{ zuul_ip }}:8888"
 
 zuul_merger_url: "http://{{ zuul_ip }}:{{ zuul_merger_apache_port }}/p"
+zuul_logs_url: "http://{{ logs_ip }}"
 zuul_statsd_enable: no

--- a/inventory/group_vars/production
+++ b/inventory/group_vars/production
@@ -50,4 +50,5 @@ nodepool_zmq_publishers:
   - tcp://zuul.bonnyci-internal.portbleu.com:8888
 
 zuul_gearman_server: zuul.bonnyci-internal.portbleu.com
+zuul_logs_url: http://logs.bonnyci.com
 zuul_use_datadog_logging: yes

--- a/inventory/group_vars/vagrant
+++ b/inventory/group_vars/vagrant
@@ -29,3 +29,4 @@ nodepool_gearman_servers:
 
 zuul_statsd_enable: no
 zuul_gearman_server: zuul.vagrant
+zuul_logs_url: http://logs.vagrant

--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -9,6 +9,8 @@ zuul_gearman_server_start: true
 zuul_gearman_server_log_config: /etc/zuul/gearman-logging.conf
 zuul_gearman_server_listen_address: 127.0.0.1
 
+zuul_logs_url: http://{{ ansible_fqdn }}
+
 zuul_statsd_enable: no
 zuul_statsd_host: 127.0.0.1
 zuul_statsd_port: 8125

--- a/roles/zuul/templates/etc/zuul/config/layout.yaml
+++ b/roles/zuul/templates/etc/zuul/config/layout.yaml
@@ -21,7 +21,7 @@ pipelines:
     success:
       github:
         status: true
-        status_url: &log_link http://logs.bonnyci.com/{pipeline.name}/{change.project.name}/{change.number}/{item.enqueue_time}/
+        status_url: &log_link "{{ zuul_logs_url }}/{pipeline.name}/{change.project.name}/{change.number}/{item.enqueue_time}/"
         comment: false
     failure:
       github:

--- a/roles/zuul/templates/etc/zuul/zuul.conf
+++ b/roles/zuul/templates/etc/zuul/zuul.conf
@@ -32,7 +32,7 @@ layout_config = /etc/zuul/config/layout.yaml
 log_config = /etc/zuul/server-logging.conf
 pidfile = /var/run/zuul-server/zuul-server.pid
 state_dir = /var/lib/zuul
-url_pattern = http://logs.bonnyci.com/{build.parameters[LOG_PATH]}
+url_pattern = {{ zuul_logs_url }}/{build.parameters[LOG_PATH]}
 
 [launcher]
 jenkins_jobs=/var/lib/zuul/jobs


### PR DESCRIPTION
The zuul layout and config both reference the production site
logs.bonnyci.com. Replace those with a variable so that tests and other
deploys don't have to reply on this.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>