### PR TITLE
Add ansible for provisioning network resources on new cloud

### DIFF
--- a/roles/cloud-bootstrap/defaults/main.yml
+++ b/roles/cloud-bootstrap/defaults/main.yml
@@ -1,0 +1,23 @@
+controlplane_network_cidr: 192.168.10.0/24
+nodepool_network_cidr: 10.0.0.0/8
+external_network_name: external
+security_group_rules:
+  - name: sg-control-plane
+    rules:
+      - remote_group: sg-control-plane
+        port_min: 1
+        port_max: 65535
+  - name: sg-zuul-merger
+    rules:
+      - remote_cidr: "{{ nodepool_network_cidr }}"
+        port: 8858
+  - name: sg-ssh
+    rules:
+      - remote_cidr: 0.0.0.0/0
+        port: 22
+  - name: sg-http-https
+    rules:
+      - remote_cidr: 0.0.0.0/0
+        port: 80
+      - remote_cidr: 0.0.0.0/0
+        port: 443

--- a/roles/cloud-bootstrap/tasks/main.yml
+++ b/roles/cloud-bootstrap/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Provision network resources
+  include: network.yml
+  tags:
+    - network

--- a/roles/cloud-bootstrap/tasks/network.yml
+++ b/roles/cloud-bootstrap/tasks/network.yml
@@ -1,0 +1,53 @@
+---
+- name: Create control-plane network
+  os_network:
+    cloud: "{{ cloud }}"
+    name: control-plane
+
+- name: Create control-plane subnet
+  os_subnet:
+    cloud: "{{ cloud }}"
+    name: control-plane-subnet
+    network_name: control-plane
+    cidr: "{{ controlplane_network_cidr }}"
+
+- name: Create nodepool network
+  os_network:
+    cloud: "{{ cloud }}"
+    name: nodepool
+    shared: true
+
+- name: Create nodepool subnet
+  os_subnet:
+    cloud: "{{ cloud }}"
+    name: nodepool-subnet
+    network_name: nodepool
+    cidr: "{{ nodepool_network_cidr }}"
+
+- name: Create router
+  os_router:
+    cloud: "{{ cloud }}"
+    name: bonnyci-router
+    network: "{{ external_network_name }}"
+    interfaces:
+        - control-plane-subnet
+        - nodepool-subnet
+
+- name: Create security groups
+  os_security_group:
+    cloud: "{{ cloud }}"
+    name: "{{ item.name }}"
+  with_items: "{{ security_group_rules }}"
+
+- name: Create security group rules
+  os_security_group_rule:
+    cloud: "{{ cloud }}"
+    security_group: "{{ item.0.name }}"
+    protocol:  "{{ item.1.protocol | default('tcp') }}"
+    port_range_min: "{{ item.1.port_min | default(item.1.port)  }}"
+    port_range_max: "{{ item.1.port_max | default(item.1.port) }}"
+    remote_ip_prefix: "{{ item.1.remote_cidr | default(omit) }}"
+    remote_group: "{{ item.1.remote_group | default(omit) }}"
+  with_subelements:
+    - "{{ security_group_rules }}"
+    -  "rules"


### PR DESCRIPTION
This adds some new provisioning code for bootstrapping our new cloud
with network resources. It creates a new 'cloud_bootstrap' role that will
supercede the old 'create-hosts' role.  The new one will encompass more than
just hosts and encompass managing production users/projects/roles,  networks,
servers, etc.

Resolves-Issue: BonnyCI/projman#133