### PR TITLE
Add dd-elasticsearch role

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -15,7 +15,7 @@
         - letsencrypt
       when:
         - letsencrypt_csr_cn | default(False)
-        
+
 - name: Install ELK
   hosts: monitoring
   become: yes
@@ -25,6 +25,11 @@
       tags: ['elasticsearch']
       elasticsearch_index_settings:
         number_of_replicas: 0
+
+    - role: dd-elasticsearch
+      tags:
+        - monitoring
+
     - role: logstash
       tags: ['logstash']
     - role: kibana

--- a/roles/dd-elasticsearch/defaults/main.yml
+++ b/roles/dd-elasticsearch/defaults/main.yml
@@ -1,0 +1,1 @@
+dd_elasticsearch_url: http://localhost:9200

--- a/roles/dd-elasticsearch/meta/main.yml
+++ b/roles/dd-elasticsearch/meta/main.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+  - role: dd-checks
+    datadog_checks:
+      elastic:
+        instances:
+          - url: "{{ dd_elasticsearch_url }}"


### PR DESCRIPTION
Datadog has an inbuilt integration for elasticsearch. It's pretty easy
to turn this on for our deployment.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>