### PR TITLE
Use python-app variables for os_loganalyze venv path

### DIFF
--- a/roles/os-loganalyze/defaults/main.yml
+++ b/roles/os-loganalyze/defaults/main.yml
@@ -1,6 +1,3 @@
-os_loganalyze_source_dir: /opt/source/os-loganalyze
-os_loganalyze_venv_dir: /opt/venv/os-loganalyze
-
 os_loganalyze_file_conditions: []
 os_loganalyze_git_version: master
 os_loganalyze_root_dir: '/var/www/bonnyci'

--- a/roles/os-loganalyze/templates/etc/os_loganalyze/wsgi/os-loganalyze.py
+++ b/roles/os-loganalyze/templates/etc/os_loganalyze/wsgi/os-loganalyze.py
@@ -1,4 +1,4 @@
-#!{{ os_loganalyze_venv_dir }}/bin/python
+#!{{ os_loganalyze_venv_path }}/bin/python
 
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-activate_this_file = "{{ os_loganalyze_venv_dir }}/bin/activate_this.py"
+activate_this_file = "{{ os_loganalyze_venv_path }}/bin/activate_this.py"
 execfile(activate_this_file, dict(__file__=activate_this_file))
 
 import threading


### PR DESCRIPTION
The python-app role will set the variables for the venv and source dir
so that dependant roles can use them. This means you aren't going to end
up with a mispelt path - like we have now.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>