### PR TITLE
Add logstash grok filter to match our python logging format

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -90,17 +90,22 @@
             - notifempty
 
     - role: filebeat
-      tags: test1
       filebeat_prospectors:
         - name: zuul-server
           prospectors:
             - input_type: log
+              document_type: python-logging
               tags:
-                - python-logging
                 - zuul
+                - zuul-launcher
+                - zuul-server
               paths:
                 - /var/log/zuul/launcher.log
                 - /var/log/zuul/server.log
+              multiline:
+                match: after
+                negate: true
+                pattern: '^[0-9]{4}-[0-9]{2}-[0-9]{2}'
 
 - name: Install zuul mergers
   hosts: mergers
@@ -136,12 +141,16 @@
         - name: zuul-merger
           prospectors:
             - input_type: log
+              document_type: python-logging
               tags:
-                - python-logging
                 - zuul
                 - zuul-merger
               paths:
                 - /var/log/zuul/merger.log
+              multiline:
+                match: after
+                negate: true
+                pattern: '^[0-9]{4}-[0-9]{2}-[0-9]{2}'
 
 - name: Install nodepool
   hosts: nodepool
@@ -173,14 +182,18 @@
         - name: nodepool
           prospectors:
             - input_type: log
+              document_type: python-logging
               tags:
-                - python-logging
                 - nodepool
               paths:
                 - /var/log/nodepool/nodepool-builder.log
                 - /var/log/nodepool/nodepool-deleter.log
                 - /var/log/nodepool/nodepool-launcher.log
                 - /var/log/nodepool/nodepoold.log
+              multiline:
+                match: after
+                negate: true
+                pattern: '^[0-9]{4}-[0-9]{2}-[0-9]{2}'
 
 - name: Install logging
   hosts: log

--- a/roles/logstash/files/etc/logstash/conf.d/13-python.conf
+++ b/roles/logstash/files/etc/logstash/conf.d/13-python.conf
@@ -1,0 +1,24 @@
+filter {
+  if [type] == "python-logging" {
+
+    grok {  # You can check grok patterns at http://grokdebug.herokuapp.com/
+      match => { "message" => "%{TIMESTAMP_ISO8601:logdate}%{SPACE}%{LOGLEVEL:loglevel}%{SPACE}(?<py_module>[0-9a-zA-Z.]+):%{SPACE}%{GREEDYDATA:logmessage}" }
+      add_field => { "received_at" => "%{@timestamp}" }
+    }
+
+    if ! ("_grokparsefailure" in [tags]) {
+      date {
+        match => [ "logdate", "ISO8601" ]
+        timezone => "UTC"
+      }
+      mutate {
+        replace => { "message" => "%{logmessage}" }
+      }
+      mutate {
+        remove_field => [ "logdate", "logmessage" ]
+      }
+    }
+
+  }
+}
+


### PR DESCRIPTION
Change our filebeat/logstash type from `log` to `python-logging` (to set
the logs apart from other log types we may add such as apache), and create
a logstash filter to parse python-logging format logs. Also, configure
filebeat multiline parsing to group tracebacks into a single event.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>