### PR TITLE
Move apache status page to a different port

### DIFF
--- a/roles/apache/templates/vhost.conf
+++ b/roles/apache/templates/vhost.conf
@@ -2,7 +2,11 @@
 
 {{ item.global_vhost_settings | default("") }}
 
+{% if item.listen_host | default(False) %}
+Listen {{ item.listen_host }}:{{ item.port | default(default_port) }}
+{% else %}
 Listen {{ item.port | default(default_port) }}
+{% endif %}
 
 <VirtualHost {{ item.host | default("_default_") }}:{{ item.port | default(default_port) }}>
 {% if item.server_name is defined %}

--- a/roles/dd-apache/defaults/main.yml
+++ b/roles/dd-apache/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
-dd_apache_status_url: http://localhost/server-status?auto
+dd_apache_status_url: "http://localhost:{{ dd_apache_status_port }}/server-status?auto"
+dd_apache_status_port: 9971
 dd_apache_disable_ssl_validation: false
 dd_apache_connect_timeout: 5
 dd_apache_receive_timeout: 15

--- a/roles/dd-apache/meta/main.yml
+++ b/roles/dd-apache/meta/main.yml
@@ -1,7 +1,29 @@
 ---
 dependencies:
-  - role: dd-checks
+  - role: apache
+    apache_mods_enabled:
+      - status.load
+    apache_mods_disabled:
+      - status.conf
+    apache_vhosts:
+      - name: status
+        host: "127.0.0.1"
+        listen_host: "127.0.0.1"
+        port: "{{ dd_apache_status_port }}"
+        global_vhost_settings: |
+          ExtendedStatus On
 
+        vhost_extra: |
+          <Location /server-status>
+            SetHandler server-status
+            Require local
+          </Location>
+
+          <IfModule mod_proxy.c>
+            ProxyStatus On
+          </IfModule>
+
+  - role: dd-checks
     datadog_checks:
       apache:
         instances:

--- a/roles/dd-apache/tasks/main.yml
+++ b/roles/dd-apache/tasks/main.yml
@@ -1,4 +1,0 @@
-- name: enable mod_status
-  apache2_module:
-    state: present
-    name: status


### PR DESCRIPTION
The apache status module helpfully installs itself by default onto all
vhosts, but restricts itself to localhost. This is questionable
behaviour anyway but it does not play nicely with our log rendering on
the logs server and so dd-apache is failing on that machine.

Construct a new vhost on a random port that only listens on localhost
and serves the status url. Then point the datadog check to this port
instead.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>