### PR TITLE
Port over create-hosts to new cloud-bootstrap + cloud-ready roles

### DIFF
--- a/create-cloud-resources.yml
+++ b/create-cloud-resources.yml
@@ -4,6 +4,9 @@
   roles:
     - role: cloud-bootstrap
       cloud: opentech-sjc
+      dns_subdomain: internal.opentechsjc.bonnyci.org
+      default_ssh_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDSpmsWVIxgSe3yUBSmuDRgMZbK/vmzxMxhaMwD7vy3/voGUvx9ozxJNonY2TKF4eyWP9t2I+HFnVgSn+4LjC2t2UlUWbHB01uVtkz5avwzUaHMYuEHh25jFOoy8/mxrop11WMZleW1Hn1txRZl68H22n6IuTySKSY1HgjHyHlP3seKwZHIMAuIg1MN5LYGlyLvJ8Ew7r0B5sU/vQs6kCUnnV2NsevtaSH1k9UPLfvO8HN7pYrY057eBLEQ9r51wj2O9nL8wvso5nXWHIhuEJiZL+573Jy9PabTMt+QaQ9t2ISedyUX/dVR3H8SKmjOkvxNjmuVyMnFkotjlqEOOTGLCDsuSlg22NbF5aXuHe12ucCcwE8I/UXecZMkSfrnhoBi3y6MFcQxgwlK06V6bTOOy9LITjvMVD7COlzITSYF/y6nhkeGKGsQ8jRfWyyXoZACNwGX3DYSSZC/X3CDcJIuhJab3jfcYap/ue2GEX2p/6MN+NbZknHTX0KZU4qNf2UVnLBH8GWbcFYqG1WwERk5ClzYIvCjn2JY21Ztqvig4vQ0NKwAIBjgOk01C5c63MTRFdBAybE8AjzCr9Zp6ADcsHXRIB9olEHfSdIKCE5ynYutw9yTO7zTpRYA2gOBNlapUFxux2DNauSeNaCkA328UU94CKYr8Rh4mDM4z4seEw== cideploy@bonnyci
+      image_uuid: f4611a28-112d-4383-ad3c-b8792572c5f0
       users:
         - username: adam_g
           email: adam.gandelman@ibm.com
@@ -20,3 +23,38 @@
         - username: mctaylor
           email: mctaylor@us.ibm.com
           isadmin: False
+      servers:
+        - name: bastion
+          floating_ip_address: 169.44.171.83
+          security_groups:
+            - sg-control-plane
+            - sg-http-https
+            - sg-ssh
+        - name: elk
+          floating_ip_address: 169.44.171.88
+          flavor: m1.xlarge
+          security_groups:
+            - sg-control-plane
+            - sg-http-https
+          key_name: "{{ deploy_ssh_key_name }}"
+        - name: logs
+          floating_ip_address: 169.44.171.84
+          security_groups:
+            - sg-control-plane
+            - sg-http-https
+          key_name: "{{ deploy_ssh_key_name }}"
+        - name: nodepool
+          security_groups:
+            - sg-control-plane
+          key_name: "{{ deploy_ssh_key_name }}"
+        - name: merger01
+          security_groups:
+            - sg-control-plane
+            - sg-zuul-merger
+          key_name: "{{ deploy_ssh_key_name }}"
+        - name: zuul
+          floating_ip_address: 169.44.171.85
+          security_groups:
+            - sg-control-plane
+            - sg-http-https
+          key_name: "{{ deploy_ssh_key_name }}"

--- a/ready-cloud-resources.yml
+++ b/ready-cloud-resources.yml
@@ -1,0 +1,6 @@
+---
+- name: Create cloud resources and accounts
+  hosts: all
+  roles:
+    - role: cloud-ready
+      cloud: opentech-sjc

--- a/roles/cloud-bootstrap/defaults/main.yml
+++ b/roles/cloud-bootstrap/defaults/main.yml
@@ -1,6 +1,39 @@
+# Production environments expect hostnames on this domain to be resolvable
+# to the instances internal address on the control-plane network.
+dns_subdomain: bonnyci.local
+
 controlplane_network_cidr: 192.168.10.0/24
 nodepool_network_cidr: 10.0.0.0/8
 external_network_name: external
+
+# In production, we will split the control-plane services and nodepool slaves
+# across tenants.  In development environments, this can be set to false to
+# enable everything running in one project.
+split_tenants: true
+
+# The existing glance image to use for service VMs.
+image_uuid: d21400df-005a-41e5-af20-70c153948218
+
+# A nova keypair will be created with this name, using the public key
+# found in secrets['ssh_keys']['cideploy']['public']
+deploy_ssh_key_name: cideploy
+
+# A default nova keypair will be created using this key and will be used
+# when booting the bastion host
+default_ssh_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQDoitDW0TOltJtxOLZWlT6SP/5dAtsewCqvAugyOGLsNBnWCqtw4LWWWKgch4ugPsLYTowEtW5mn/6e4A+OjCDB/zsunXJxxLhySRldChXWwrjnwfAvhgt7KIPG35SuKXjkb4DX0NhI8qytRwz+tq9Xf5hTUKb8o5t6PS56vqiBkQ== testing
+
+default_flavor: m1.medium
+
+users: []
+default_password: CHANGEME1234
+prod_project: bonnyci
+prod_group: bonnyci
+prod_admin_group: bonnyci-admin
+prod_member_role: _member_
+prod_admin_role: cloud_admin
+prod_nodepool_user: nodepool
+prod_nodepool_project: nodepool
+
 security_group_rules:
   - name: sg-control-plane
     rules:
@@ -22,12 +55,37 @@ security_group_rules:
       - remote_cidr: 0.0.0.0/0
         port: 443
 
-users: []
-default_password: CHANGEME1234
-prod_project: bonnyci
-prod_group: bonnyci
-prod_admin_group: bonnyci-admin
-prod_member_role: _member_
-prod_admin_role: cloud_admin
-prod_nodepool_user: nodepool
-prod_nodepool_project: nodepool
+servers:
+  - name: bastion
+    floating_ip_network: "{{ external_network_name }}"
+    security_groups:
+      - sg-control-plane
+      - sg-http-https
+      - sg-ssh
+  - name: elk
+    floating_ip_network: "{{ external_network_name }}"
+    security_groups:
+      - sg-control-plane
+      - sg-http-https
+    key_name: "{{ deploy_ssh_key_name }}"
+  - name: logs
+    floating_ip_network: "{{ external_network_name }}"
+    security_groups:
+      - sg-control-plane
+      - sg-http-https
+    key_name: "{{ deploy_ssh_key_name }}"
+  - name: nodepool
+    security_groups:
+      - sg-control-plane
+    key_name: "{{ deploy_ssh_key_name }}"
+  - name: merger01
+    security_groups:
+      - sg-control-plane
+      - sg-zuul-merger
+    key_name: "{{ deploy_ssh_key_name }}"
+  - name: zuul
+    floating_ip_network: "{{ external_network_name }}"
+    security_groups:
+      - sg-control-plane
+      - sg-http-https
+    key_name: "{{ deploy_ssh_key_name }}"

--- a/roles/cloud-bootstrap/tasks/hosts.yml
+++ b/roles/cloud-bootstrap/tasks/hosts.yml
@@ -1,0 +1,21 @@
+---
+- name: Create hosts
+  os_server:
+    cloud: "{{ cloud }}"
+    name: "{{ item.name }}.{{ dns_subdomain }}"
+    flavor: "{{ item.flavor | default(default_flavor) }}"
+    image: "{{ image_uuid }}"
+    key_name: "{{ item.key_name | default('default') }}"
+    network: control-plane
+    auto_ip: false
+    security_groups: "{{ item.security_groups }}"
+  with_items: "{{ servers }}"
+
+- name: Associate floating IPs
+  os_floating_ip:
+    cloud: "{{ cloud }}"
+    server: "{{ item.name }}.{{ dns_subdomain }}"
+    network: "{{ item.floating_ip_network | default(omit) }}"
+    floating_ip_address: "{{ item.floating_ip_address | default(omit) }}"
+  with_items: "{{ servers }}"
+  when: item.floating_ip_address is defined or item.floating_ip_network is defined

--- a/roles/cloud-bootstrap/tasks/keys.yml
+++ b/roles/cloud-bootstrap/tasks/keys.yml
@@ -1,0 +1,12 @@
+---
+- name: Create default key pair
+  os_keypair:
+    cloud: "{{ cloud }}"
+    name: default
+    public_key: "{{ default_ssh_key }}"
+
+- name: Create cideploy key pair
+  os_keypair:
+    cloud: "{{ cloud }}"
+    name: "{{ deploy_ssh_key_name }}"
+    public_key: "{{ secrets.ssh_keys.cideploy.public }}"

--- a/roles/cloud-bootstrap/tasks/main.yml
+++ b/roles/cloud-bootstrap/tasks/main.yml
@@ -8,3 +8,13 @@
   include: network.yml
   tags:
     - network
+
+- name: Create ssh key pairs
+  include: keys.yml
+  tags:
+    - keys
+
+- name: Create hosts
+  include: hosts.yml
+  tags:
+    - hosts

--- a/roles/cloud-bootstrap/tasks/network.yml
+++ b/roles/cloud-bootstrap/tasks/network.yml
@@ -23,7 +23,7 @@
   os_network:
     cloud: "{{ cloud }}"
     name: nodepool
-    shared: true
+    shared: "{{ split_tenants }}"
     project: "{{ prod_project }}"
     auth:
       project_name: "{{ prod_project }}"

--- a/roles/cloud-ready/tasks/known_hosts.yml
+++ b/roles/cloud-ready/tasks/known_hosts.yml
@@ -1,0 +1,32 @@
+---
+- block:
+  - name: wait for new host to respond to ssh
+    wait_for:
+      port: 22
+      host: "{{ item.private_v4 }}"
+      search_regex: OpenSSH
+
+  - name: scan the ssh key of the new host via private address
+    command: "{{ 'ssh-keyscan -t rsa ' +  item.private_v4 }}"
+    register: keyscan_private_v4
+
+  - name: scan the ssh key of the new host via internal dns address
+    ignore_errors: yes
+    command: "{{ 'ssh-keyscan -t rsa ' +  item.name }}"
+    register: keyscan_internal_dns
+
+  - name: ensure new servers private_v4 are in known_hosts
+    become: true
+    known_hosts:
+      path: /etc/ssh/ssh_known_hosts
+      name: "{{ item.private_v4 }}"
+      key: "{{ keyscan_private_v4.stdout }}"
+
+  - name: ensure new servers public_v4/dns are in known_hosts
+    become: true
+    known_hosts:
+      path: /etc/ssh/ssh_known_hosts
+      name: "{{ item.name }}"
+      key: "{{ keyscan_internal_dns.stdout }}"
+    ignore_errors: yes
+    when: keyscan_internal_dns

--- a/roles/cloud-ready/tasks/main.yml
+++ b/roles/cloud-ready/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Gather instance facts
+  run_once: true
+  delegate_to: localhost
+  os_server_facts:
+    cloud: "{{ cloud }}"
+
+- name: Add ssh host keys to bastion known hosts
+  run_once: true
+  delegate_to: "{{ groups.bastion[0] }}"
+  include: known_hosts.yml
+  with_items: "{{ openstack_servers }}"

--- a/tests/test-hoist-ansible.sh
+++ b/tests/test-hoist-ansible.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 echo "Running hoist ansible syntax test"
-ansible-playbook -i /dev/null --syntax-check $(find . tests -maxdepth 1 -type f -name \*.yml -not -name .travis.yml)
+ansible-playbook -i tests/test-inventory --syntax-check $(find . tests -maxdepth 1 -type f -name \*.yml -not -name .travis.yml)
 
 echo "Running hoist ansible deployment test"
 ansible-playbook -i inventory/nodepool.py install-ci.yml --skip-tags monitoring,letsencrypt -e @secrets.yml.example

--- a/tests/test-inventory
+++ b/tests/test-inventory
@@ -1,0 +1,4 @@
+test-bastion ansible_ssh_host=127.0.0.1 ansible_ssh_user=ubuntu
+
+[bastion]
+test-bastion


### PR DESCRIPTION
This ports over the code we used to create new hosts from the
create-hosts role into the new, more modular cloud-bootstrap and
cloud-ready roles for provisioning prod and dev environments.

2 SSH keys get created:

 * A default key (specified in cloud-bootstrap defaults) that is
   used to boot and initially access the bastion
 * A cideploy key (specified via secrets) that is used to boot
   other nodes that will be under management of automation on
   the bastion's.

The cloud-bootstrap role will boot instances with specific secgroups,
and associate floating IPs either from a network or using a specific IP.

After the cloud-bootstrap role has run, prod environments are expected
to update DNS for the domain specified in dns_subdomain, so that the
FQDNs of each instance (as specified by instance name) point to the
private ipv4 address of each.  For developer environments, this is not
necessary.

After DNS has been updated, the cloud-ready role may be run against
a bastion to complete final tasks necessary prior to deploying the
bastion itself.  This includes ssh keyscans of private addresses
and hostnames.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>