### PR TITLE
Defined zuul_sites per environment

### DIFF
--- a/inventory/group_vars/allinone
+++ b/inventory/group_vars/allinone
@@ -17,6 +17,12 @@ nodepool_providers:
 bastion_clouds:
   - cicloud
 
+zuul_sites:
+  bonnyci-scp:
+    host: localhost
+    user: zuul
+    root: /var/www/bonny-logs
+
 # commented out variable to show what one could point to with a -e argument
 # if they wanted to make use of an ssh-config file at execution time.
 # ansible_ssh_common_args: -F inventory/allinone-ssh-config

--- a/inventory/group_vars/multinode
+++ b/inventory/group_vars/multinode
@@ -39,4 +39,9 @@ nodepool_zmq_publishers:
 
 zuul_merger_url: "http://{{ zuul_ip }}:{{ zuul_merger_apache_port }}/p"
 zuul_logs_url: "http://{{ logs_ip }}"
+zuul_sites:
+  bonnyci-scp:
+    host: "{{ logs_ip }}"
+    user: zuul
+    root: /var/www/bonny-logs
 zuul_statsd_enable: no

--- a/inventory/group_vars/production
+++ b/inventory/group_vars/production
@@ -51,4 +51,9 @@ nodepool_zmq_publishers:
 
 zuul_gearman_server: zuul.bonnyci-internal.portbleu.com
 zuul_logs_url: http://logs.bonnyci.com
+zuul_sites:
+  bonnyci-scp:
+    host: logs.bonnyci.com
+    user: zuul
+    root: /var/www/bonny-logs
 zuul_use_datadog_logging: yes

--- a/inventory/group_vars/vagrant
+++ b/inventory/group_vars/vagrant
@@ -30,3 +30,8 @@ nodepool_gearman_servers:
 zuul_statsd_enable: no
 zuul_gearman_server: zuul.vagrant
 zuul_logs_url: http://logs.vagrant
+zuul_sites:
+  bonnyci-scp:
+    host: logs.vagrant
+    user: zuul
+    root: /var/www/bonny-logs

--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -27,8 +27,4 @@ zuul_git_user_email: My Name
 zuul_connections: {}
 zuul_use_datadog_logging: False
 
-zuul_sites:
-  bonnyci-scp:
-    host: logs.bonnyci.com
-    user: zuul
-    root: /var/www/bonny-logs
+zuul_sites: {}


### PR DESCRIPTION
zuul_sites becomes the sites that the jobs can specify to upload logs
to. At the moment because this is defined in the role even test
environments are trying to upload to the production zuul logs server.

Set the role default to not produce any zuul sites, copy the existing
information to production and set up some sensible defaults for the
other environments.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>