### PR TITLE
Tighten up network resource creation

### DIFF
--- a/roles/cloud-bootstrap/tasks/network.yml
+++ b/roles/cloud-bootstrap/tasks/network.yml
@@ -3,34 +3,42 @@
   os_network:
     cloud: "{{ cloud }}"
     name: control-plane
+    project: "{{ prod_project }}"
     auth:
       project_name: "{{ prod_project }}"
+  register: control_plane_network
 
 - name: Create control-plane subnet
   os_subnet:
     cloud: "{{ cloud }}"
     name: control-plane-subnet
-    network_name: control-plane
+    network_name: "{{ control_plane_network.network.id }}"
     cidr: "{{ controlplane_network_cidr }}"
+    project: "{{ prod_project }}"
     auth:
       project_name: "{{ prod_project }}"
+  register: control_plane_subnet
 
 - name: Create nodepool network
   os_network:
     cloud: "{{ cloud }}"
     name: nodepool
     shared: true
+    project: "{{ prod_project }}"
     auth:
       project_name: "{{ prod_project }}"
+  register: nodepool_network
 
 - name: Create nodepool subnet
   os_subnet:
     cloud: "{{ cloud }}"
     name: nodepool-subnet
-    network_name: nodepool
+    network_name: "{{ nodepool_network.network.id }}"
     cidr: "{{ nodepool_network_cidr }}"
+    project: "{{ prod_project }}"
     auth:
       project_name: "{{ prod_project }}"
+  register: nodepool_subnet
 
 - name: Create router
   os_router:
@@ -38,8 +46,9 @@
     name: bonnyci-router
     network: "{{ external_network_name }}"
     interfaces:
-        - control-plane-subnet
-        - nodepool-subnet
+        - "{{ control_plane_subnet.subnet.id }}"
+        - "{{ nodepool_subnet.subnet.id }}"
+    project: "{{ prod_project }}"
     auth:
       project_name: "{{ prod_project }}"
 
@@ -65,3 +74,16 @@
   with_subelements:
     - "{{ security_group_rules }}"
     -  "rules"
+
+- name: Create nodepool SSH security group rule
+  os_security_group_rule:
+    cloud: "{{ cloud }}"
+    security_group: "default"
+    protocol: "tcp"
+    port_range_min: "22"
+    port_range_max: "22"
+    remote_ip_prefix: "{{ controlplane_network_cidr }}"
+    auth:
+      project_name: "{{ prod_nodepool_project }}"
+
+


### PR DESCRIPTION
The openstack modules and shade resolve things via name by default.
This is a problem if running automation with admin credentials and
other tenants have created resources with the same name, as admin
can view all of them and automation will blow up on colliding names.

This tightens it up by registering ids and passing those instead of
names. It also passes the 'project' argument to further
tighten its queries.

Also, this creates the required hole in nodepool's default security
group so things can reach its slaves via ssh from the control-plane.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>