### PR TITLE
Create a zuul user on the logs server

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -15,7 +15,7 @@
         - letsencrypt
       when:
         - letsencrypt_csr_cn | default(False)
-        
+
 - name: Install ELK
   hosts: monitoring
   become: yes
@@ -199,6 +199,19 @@
   hosts: log
   become: yes
   tags: ['logs']
+
+  pre_tasks:
+    - name: Create a user logs can be uploaded as
+      user:
+        name: zuul
+        home: /var/lib/zuul
+
+    - name: Add authorized key to logs user
+      authorized_key:
+        user: zuul
+        exclusive: yes
+        key: "{{ secrets.ssh_keys.zuul.public }}"
+
   roles:
     - role: os-loganalyze
       os_loganalyze_root_dir: "{{ bonnyci_logs_root_dir }}"


### PR DESCRIPTION
The zuul launcher will try to rsync from the worker to the logs server
as the zuul user. Somehow this is present in production but not created
by hoist.

Add a task that simply creates a user and adds the authorized key so
that logs can be uploaded.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>