### PR TITLE
Create an ansible role to install quartermaster

### DIFF
--- a/quartermaster.yml
+++ b/quartermaster.yml
@@ -1,0 +1,15 @@
+---
+# Quartermaster installer playbook
+# 
+# Install with 'ansible-playbook quartermaster.yml -e @/etc/secrets.yml'
+#
+# Should be run on the host you want to install on (localhost)
+- name: Install quartermaster
+  hosts: localhost
+  become: true
+
+  roles:
+    - role: quartermaster
+      quartermaster_channels: "#BonnyCI"
+      quartermaster_nick: "quartermaster"
+      quartermaster_install_tag: "0.2.0-DEV"

--- a/roles/quartermaster/defaults/main.yml
+++ b/roles/quartermaster/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+quartermaster_channels: ""
+quartermaster_nick: "quartermaster"
+quartermaster_debug: "true"
+quartermaster_database_path: "/var/lib/quartermaster/quartermaster.db"
+quartermaster_loglevel: "DEBUG"
+
+quartermaster_install_base_url: "https://github.com/BonnyCI/quartermaster/releases/download/"
+quartermaster_install_tag: "0.2.0-DEV"
+quartermaster_install_zip_filename: "quartermaster-{{ quartermaster_install_tag }}.zip"
+quartermaster_install_url: "{{ quartermaster_install_base_url }}/v{{ quartermaster_install_tag }}/{{ quartermaster_install_zip_filename }}"

--- a/roles/quartermaster/handlers/main.yml
+++ b/roles/quartermaster/handlers/main.yml
@@ -1,0 +1,13 @@
+---
+- name: Reload systemd units
+  command: systemctl daemon-reload
+
+- name: Restart quartermaster
+  service:
+    name: quartermaster
+    state: restarted
+
+- name: Init database
+  shell: /opt/quartermaster/quartermaster init --config /etc/quartermaster/quartermaster.yaml --loglevel debug
+  args:
+    executable: /bin/bash

--- a/roles/quartermaster/tasks/main.yml
+++ b/roles/quartermaster/tasks/main.yml
@@ -1,0 +1,85 @@
+---
+- name: install dependencies
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - unzip
+
+- name: Create the quartermaster group
+  group:
+    name: quartermaster
+    state: present
+
+- name: Create quartermaster user
+  user:
+    name: quartermaster
+    group: quartermaster
+    home: /var/lib/quartermaster
+    system: yes
+    state: present
+
+- name: Create directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: 0755
+    owner: quartermaster
+    group: quartermaster
+  with_items:
+    - /etc/quartermaster
+    - /var/log/quartermaster
+    - /opt/quartermaster
+
+- name: Download quartermaster binary
+  get_url:
+    url: "{{ quartermaster_install_url }}"
+    dest: /tmp
+
+- name: Install quartermaster binary
+  unarchive:
+    src: "/tmp/{{ quartermaster_install_zip_filename }}"
+    dest: /opt/quartermaster
+    remote_src: True
+
+- name: Install quartermaster config
+  template:
+    src: etc/quartermaster/config.yaml
+    dest: /etc/quartermaster/config.yaml
+    owner: quartermaster
+    mode: 0600
+  notify: Restart quartermaster
+
+- name: Check for quartermaster database
+  stat:
+    path: "{{ quartermaster_database_path }}"
+  register: qm_database
+
+- name: Init database if missing
+  shell: /opt/quartermaster/quartermaster init --config /etc/quartermaster/config.yaml --loglevel debug
+  args:
+    executable: /bin/bash
+  become: yes
+  become_user: quartermaster
+  when: qm_database.stat.exists is defined and qm_database.stat.exists == False
+
+- name: Install systemd unit files
+  template:
+    src: "etc/systemd/system/{{ item }}.service"
+    dest: "/etc/systemd/system/{{ item }}.service"
+    owner: root
+    group: root
+    mode: 0644
+  with_items:
+    - quartermaster
+  notify:
+    - Reload systemd units
+    - Restart quartermaster
+
+- meta: flush_handlers
+
+- name: Enable and start systemd service
+  service:
+    enabled: yes
+    state: started
+    service: quartermaster

--- a/roles/quartermaster/templates/etc/quartermaster/config.yaml
+++ b/roles/quartermaster/templates/etc/quartermaster/config.yaml
@@ -1,0 +1,9 @@
+# {{ ansible_managed }}
+
+Channels: "{{ quartermaster_channels }}"
+Nick: "{{ quartermaster_nick }}"
+Debug: {{ quartermaster_debug }}
+Database: "{{ quartermaster_database_path }}"
+Loglevel: "{{ quartermaster_loglevel }}"
+
+{{ {'Data': secrets.quartermaster.defaults } | to_nice_yaml }}

--- a/roles/quartermaster/templates/etc/systemd/system/quartermaster.service
+++ b/roles/quartermaster/templates/etc/systemd/system/quartermaster.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Quartermaster Service
+After=syslog.target network.target
+
+[Service]
+Type=simple
+User=quartermaster
+Group=quartermaster
+ExecStart=/opt/quartermaster/quartermaster bot --config /etc/quartermaster/config.yaml --loglevel debug
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Installs quartermaster, our standup bot

This role makes a few assumptions.

1) This isn't managed with ansible-runner like the rest of our stack,
as it shouldn't be part of the critical path for our production installs
2) This is meant to be run from the bastion directly
3) secrets need to be in-place beforehand

secrets:
  quartermaster:
    defaults:
      <users>
      <groups>
      <timezones>

Fixes BonnyCI/projman#153

Signed-off-by: Bradon Kanyid <bradon@kanyid.org>