### PR TITLE
Create scp-log-receiver

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -199,22 +199,14 @@
   hosts: log
   become: yes
   tags: ['logs']
-
-  pre_tasks:
-    - name: Create a user logs can be uploaded as
-      user:
-        name: zuul
-        home: /var/lib/zuul
-
-    - name: Add authorized key to logs user
-      authorized_key:
-        user: zuul
-        exclusive: yes
-        key: "{{ secrets.ssh_keys.zuul.public }}"
-
   roles:
+    - role: scp-log-receiver
+      scp_log_receiver_user: "{{ bonnyci_logs_scp_user }}"
+      scp_log_receiver_path:  "{{ bonnyci_logs_root_dir }}/logs"
+      scp_log_receiver_authorized_key: "{{ secrets.ssh_keys.zuul.public | default(omit) }}"
+
     - role: os-loganalyze
-      os_loganalyze_root_dir: "{{ bonnyci_logs_root_dir }}"
+      os_loganalyze_root_dir: "{{ bonnyci_logs_root_dir }}/logs"
       os_loganalyze_file_conditions: "{{ bonnyci_logs_loganalyze_file_conditions }}"
 
     - role: apache

--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -1,5 +1,8 @@
 apache_ssl_use_stapling: yes
 
+bonnyci_logs_root_dir: /var/www/bonny-logs
+bonnyci_logs_scp_user: zuul
+
 filebeat_output_logstash_enabled: true
 
 hoist_repo: https://github.com/BonnyCI/hoist.git

--- a/inventory/group_vars/allinone
+++ b/inventory/group_vars/allinone
@@ -1,3 +1,5 @@
+bonnyci_logs_scp_host: localhost
+
 elasticsearch_jvm_heap_size: 250m
 
 nodepool_mysql_host: localhost

--- a/inventory/group_vars/log
+++ b/inventory/group_vars/log
@@ -7,9 +7,8 @@ bonnyci_logs_apache_mods_install:
 bonnyci_logs_apache_vhosts:
   - name: logs
     server_name: "{{ bonnyci_logs_apache_server_name | default('logs') }}"
-    document_root: "{{ bonnyci_logs_root_dir }}"
+    document_root: "{{ bonnyci_logs_root_dir }}/logs"
     document_root_allow_override: None
-    document_root_mode: "0755"
     document_root_options: "+Indexes +FollowSymLinks"
 
     vhost_extra: |
@@ -79,5 +78,3 @@ bonnyci_logs_loganalyze_file_conditions:
   - filename_pattern: ^.*$
     filter: NoFilter
     view: PassthroughView
-
-bonnyci_logs_root_dir: /var/www/bonny-logs/logs

--- a/inventory/group_vars/multinode
+++ b/inventory/group_vars/multinode
@@ -5,6 +5,7 @@ bastion_clouds:
   - bastioncloud
 
 bonnyci_logs_apache_server_name: logs.multinode
+bonnyci_logs_scp_host: "{{ logs_ip }}"
 bonnyci_zuul_webapp_apache_server_name: zuul.multinode
 
 datadog_enabled: no

--- a/inventory/group_vars/production
+++ b/inventory/group_vars/production
@@ -2,6 +2,7 @@ bastion_clouds:
   - contra-sjc
 
 bonnyci_logs_apache_server_name: logs.bonnyci.com
+bonnyci_logs_scp_host: logs.bonnyci.com
 bonnyci_zuul_webapp_apache_server_name: zuul.bonnyci.portbleu.com
 bonnyci_zuul_merger_apache_server_name: merger01.bonnyci-internal.portbleu.com
 

--- a/inventory/group_vars/vagrant
+++ b/inventory/group_vars/vagrant
@@ -1,6 +1,7 @@
 bastion_clouds:
   - bastioncloud
 
+bonnyci_logs_scp_host: logs.vagrant
 bonnyci_zuul_merger_apache_server_name: merger.vagrant
 bonnyci_zuul_webapp_apache_server_name: zuul.vagrant
 

--- a/inventory/group_vars/zuul
+++ b/inventory/group_vars/zuul
@@ -27,3 +27,9 @@ bonnyci_zuul_webapp_apache_vhosts:
 zuul_components:
   - zuul-launcher
   - zuul-server
+
+zuul_sites:
+  bonnyci-scp:
+    host: "{{ bonnyci_logs_scp_host }}"
+    user: "{{ bonnyci_logs_scp_user }}"
+    root: "{{ bonnyci_logs_root_dir }}"

--- a/roles/scp-log-receiver/defaults/main.yml
+++ b/roles/scp-log-receiver/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+scp_log_receiver_home: "/var/lib/{{ scp_log_receiver_user }}"
+scp_log_receiver_group: "scp-log-receiver"
+scp_log_receiver_group_append: yes
+
+scp_log_receiver_exclusive_authorized_key: yes

--- a/roles/scp-log-receiver/tasks/main.yml
+++ b/roles/scp-log-receiver/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: Create a group that user can belong to
+  group:
+    name: "{{ scp_log_receiver_group }}"
+    state: present
+
+- name: Create a user logs can be uploaded as
+  user:
+    name: "{{ scp_log_receiver_user | mandatory }}"
+    home: "{{ scp_log_receiver_home }}"
+    groups: "{{ scp_log_receiver_group }}"
+    append: "{{ scp_log_receiver_group_append }}"
+
+- name: Add authorized key to logs user
+  authorized_key:
+    user: "{{ scp_log_receiver_user }}"
+    exclusive: "{{ scp_log_receiver_exclusive_authorized_key }}"
+    key: "{{ scp_log_receiver_authorized_key }}"
+  when: "scp_log_receiver_authorized_key | default(False)"
+
+- name: Create receiver directory
+  file:
+    name: "{{ scp_log_receiver_path | mandatory }}"
+    state: directory
+    group: "{{ scp_log_receiver_group }}"
+    mode: "2775"
+    recurse: yes

--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -27,8 +27,4 @@ zuul_git_user_email: My Name
 zuul_connections: {}
 zuul_use_datadog_logging: False
 
-zuul_sites:
-  bonnyci-scp:
-    host: logs.bonnyci.com
-    user: zuul
-    root: /var/www/bonny-logs
+zuul_sites: {}


### PR DESCRIPTION
There are a few places between the zuul and logging servers where we
rely on coordinating a place where the launcher can upload logs to. We
need not only to have a user that can perform this operation, but a
directory with appropriate permissions.

Refactor this and make it so all environments share common site
information, but with their own scp log host.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>