### PR TITLE
Add webhook token location to secrets

### DIFF
--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -31,3 +31,4 @@ zuul_connections:
     api_token: "{{ secrets.zuul_github_api_key | default('') }}"
     integration_id: "{{ secrets.zuul_github_integration_id | default('') }}"
     integration_key: "{{ zuul_github_integration_key_file }}"
+    webhook_token: "{{ secrets.zuul_github_webhook_token | default('') }}"

--- a/secrets.yml.example
+++ b/secrets.yml.example
@@ -29,6 +29,7 @@ secrets:
       identity_api_version: '3'
       region_name: RegionOne
   zuul_github_api_key: demokey
+  zuul_github_webhook_token: webhooksigner
   ssh_keys:
     cideploy:
       private: |


### PR DESCRIPTION
We need to be able to feed the webhook secret into the zuul
configuration. This means defining a place for it to live in secrets.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>