### PR TITLE
Make SSH lockdown an opt-in task

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -5,6 +5,8 @@
   tags: ['common']
   roles:
     - role: admin-user
+      when: bonnyci_lockdown_ssh | default(False)
+
     - role: common
 
     - role: dd-agent

--- a/inventory/group_vars/production
+++ b/inventory/group_vars/production
@@ -1,6 +1,7 @@
 bastion_clouds:
   - contra-sjc
 
+bonnyci_lockdown_ssh: yes
 bonnyci_logs_apache_server_name: logs.bonnyci.com
 bonnyci_logs_scp_host: logs.bonnyci.com
 bonnyci_zuul_webapp_apache_server_name: zuul.bonnyci.portbleu.com


### PR DESCRIPTION
Locking down SSH to only allow the cideploy user is useful for
production but it effectively locks us out of our testing environments.
Make this something an environment opts in to.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>