### PR TITLE
Move old letsencrypt cert when requesting a new one

### DIFF
--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -50,6 +50,19 @@
         (not letsencrypt_stat.results.1.stat.exists) or
         (letsencrypt_create_csr.changed | default(False))
 
+- name: Backup old cert when requesting a new one
+  copy:
+    remote_src: True
+    src: "{{ letsencrypt_cert_path }}"
+    dest: "{{ letsencrypt_cert_path }}.bak"
+  when: letsencrypt_create_csr_command.changed | default(False)
+
+- name: Remove old cert when requesting a new one
+  file:
+    dest: "{{ letsencrypt_cert_path }}"
+    state: absent
+  when: letsencrypt_create_csr_command.changed | default(False)
+
 - name: set key owner
   file:
     path: "{{ letsencrypt_key_path }}"


### PR DESCRIPTION
The letsencrypt module will check the validity of the current cert before
requesting a new one, without checking that the cert and key match. If a
new key and cert request are generated while the old cert is still valid,
this leaves us with a key/cert mismatch and apache will fail to start.

If we generate a new key and/or cert request, move the old cert to a backup
location to force the letsencrypt module to generate a new cert.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>