### PR TITLE
Don't manually install jenkins-job-builder

### DIFF
--- a/roles/zuul/meta/main.yml
+++ b/roles/zuul/meta/main.yml
@@ -2,8 +2,6 @@ dependencies:
   - role: python-app
     name: zuul
     python_app_pipdeps:
-      - name: jenkins-job-builder
-        version: '1.6.1'
       - name: pyzmq
       - name: ansible
       - name: statsd


### PR DESCRIPTION
This should be considered a strict dependency of zuul and installed that
way. This is causing churn in the playbook.

Depends-On: BonnyCI/zuul#31
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>