### PR TITLE
Manually install github3 dependency in zuul

### DIFF
--- a/roles/zuul/meta/main.yml
+++ b/roles/zuul/meta/main.yml
@@ -7,6 +7,7 @@ dependencies:
       - name: pyzmq
       - name: ansible
       - name: statsd
+      - name: git+https://github.com/sigmavirus24/github3.py.git@8e9ca0056b8fed956b66dafb5398757cd8d8bed9#egg=Github3.py
     python_app_git_repo: "{{ zuul_git_repo_url }}"
     python_app_git_version: "{{ zuul_git_branch }}"
     python_app_notify: Restart zuul


### PR DESCRIPTION
Until we have sigmavirus/github3.py#671 in a release we will have to
handle this manually. Unfortunately pip install . doesn't handle git
links in requirements.txt files and so we do it in the deployment
instead.

Depends-On: bonnyci/zuul#32
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>