### PR TITLE
Use bastion host_vars for setting the cron inventory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
   fast_finish: true
 
 env:
-  - TEST_RUN="ansible-playbook -i inventory/allinone bastion.yml install-ci.yml tests/validate-ci.yml -c docker -vv -e @secrets.yml.example --skip-tags monitoring,not-on-docker,letsencrypt"
+  - TEST_RUN="ansible-playbook -i inventory/allinone bastion.yml -c docker -vv -e @secrets.yml.example --skip-tags monitoring,not-on-docker,letsencrypt"
   - TEST_RUN="ansible-playbook -i inventory/allinone install-ci.yml tests/validate-ci.yml -c docker -vv -e @secrets.yml.example --skip-tags monitoring,not-on-docker,letsencrypt"
 
 before_install:

--- a/bastion.yml
+++ b/bastion.yml
@@ -34,7 +34,7 @@
     - role: ansible-runner
       ansible_runner_job: system-ansible
       ansible_playbook: bastion.yml
-      ansible_inventory: /opt/source/system-ansible/inventory/bastion-production
+      ansible_inventory: "/opt/source/system-ansible/inventory/{{ ci_inventory }}"
       ansible_runner_user: root
       ansible_runner_repo: "{{ hoist_repo }}"
       ansible_runner_minute: "*/15"

--- a/inventory/contra-sjc
+++ b/inventory/contra-sjc
@@ -1,3 +1,6 @@
+[bastion]
+contrasjc-bastion.portbleu.com connection=local
+
 [nodepool]
 nodepool.bonnyci-internal.portbleu.com
 

--- a/inventory/group_vars/allinone
+++ b/inventory/group_vars/allinone
@@ -1,7 +1,5 @@
 bonnyci_logs_scp_host: localhost
 
-ci_inventory: allinone
-
 elasticsearch_jvm_heap_size: 250m
 
 nodepool_mysql_host: localhost

--- a/inventory/group_vars/contra-sjc
+++ b/inventory/group_vars/contra-sjc
@@ -6,8 +6,6 @@ bonnyci_logs_scp_host: logs.bonnyci.com
 bonnyci_zuul_webapp_apache_server_name: zuul.bonnyci.portbleu.com
 bonnyci_zuul_merger_apache_server_name: merger01.bonnyci-internal.portbleu.com
 
-ci_inventory: contra-sjc
-
 filebeat_output_logstash_hosts:
   - logs.bonnyci-internal.portbleu.com:5044
 

--- a/inventory/group_vars/opentech-sjc
+++ b/inventory/group_vars/opentech-sjc
@@ -6,8 +6,6 @@ bonnyci_logs_scp_host: logs.opentechsjc.bonnyci.org
 bonnyci_zuul_webapp_apache_server_name: zuul.opentechsjc.bonnyci.org
 bonnyci_zuul_merger_apache_server_name: merger01.internal.opentechsjc.bonnyci.org
 
-ci_inventory: opentech-sjc
-
 filebeat_output_logstash_hosts:
   - elk.internal.opentechsjc.bonnyci.org:5044
 

--- a/inventory/group_vars/vagrant
+++ b/inventory/group_vars/vagrant
@@ -5,8 +5,6 @@ bonnyci_logs_scp_host: logs.vagrant
 bonnyci_zuul_merger_apache_server_name: merger.vagrant
 bonnyci_zuul_webapp_apache_server_name: zuul.vagrant
 
-ci_inventory: vagrant
-
 datadog_enabled: no
 
 elasticsearch_jvm_heap_size: 250m

--- a/inventory/host_vars/allinone
+++ b/inventory/host_vars/allinone
@@ -1,3 +1,5 @@
+ci_inventory: allinone
+
 zookeeper_myid: 1
 
 zuul_components:

--- a/inventory/host_vars/bastion.opentechsjc.bonnyci.org
+++ b/inventory/host_vars/bastion.opentechsjc.bonnyci.org
@@ -1,0 +1,1 @@
+ci_inventory: opentech-sjc

--- a/inventory/host_vars/bastion.vagrant
+++ b/inventory/host_vars/bastion.vagrant
@@ -1,2 +1,4 @@
 bastion_clouds:
   - cicloud
+
+ci_inventory: vagrant

--- a/inventory/host_vars/contrasjc-bastion.portbleu.com
+++ b/inventory/host_vars/contrasjc-bastion.portbleu.com
@@ -1,0 +1,1 @@
+ci_inventory: contra-sjc

--- a/inventory/opentech-sjc
+++ b/inventory/opentech-sjc
@@ -1,3 +1,6 @@
+[bastion]
+bastion.opentechsjc.bonnyci.org connection=local
+
 [nodepool]
 nodepool.internal.opentechsjc.bonnyci.org
 

--- a/inventory/vagrant
+++ b/inventory/vagrant
@@ -1,5 +1,5 @@
 [bastion]
-localhost ansible_connection=local
+bastion.vagrant ansible_connection=local
 
 [nodepool]
 nodepool.vagrant
@@ -23,7 +23,6 @@ logs.vagrant
 logs.vagrant
 
 [vagrant]
-localhost
 nodepool.vagrant
 zuul.vagrant
 merger.vagrant


### PR DESCRIPTION
Add bastion entries in our inventories to use unique host names while
still using local connections so that we can specify the ansible inventory
to use in the cron jobs using host_vars.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>