### PR TITLE
Add datadog check for stale nodepool images

### DIFF
--- a/roles/dd-nodepool/defaults/main.yml
+++ b/roles/dd-nodepool/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 dd_nodepool_status_url:  http://locahost:8005/image-list
+dd_nodepool_images_url:  http://locahost:8005/dib-image-list.json

--- a/roles/dd-nodepool/meta/main.yml
+++ b/roles/dd-nodepool/meta/main.yml
@@ -3,6 +3,7 @@ dependencies:
   - role: dd-checks
 
     datadog_checks:
-      nodepool_server: 
+      nodepool_server:
         instances:
           - status_url: "{{ dd_nodepool_status_url }}"
+          - images_url: "{{ dd_nodepool_images_url }}"


### PR DESCRIPTION
Feeds age of all images in nodepool dib-image-list.json to datadog.

Implements: BonnyCI/projman#98

Signed-off-by: Cullen Taylor <cullentaylor@outlook.com>