### PR TITLE
Futher parameterize network resources to allow other envs

### DIFF
--- a/roles/cloud-bootstrap/defaults/main.yml
+++ b/roles/cloud-bootstrap/defaults/main.yml
@@ -2,10 +2,6 @@
 # to the instances internal address on the control-plane network.
 dns_subdomain: bonnyci.local
 
-controlplane_network_cidr: 192.168.10.0/24
-nodepool_network_cidr: 10.0.0.0/8
-external_network_name: external
-
 # In production, we will split the control-plane services and nodepool slaves
 # across tenants.  In development environments, this can be set to false to
 # enable everything running in one project.
@@ -33,6 +29,13 @@ prod_member_role: _member_
 prod_admin_role: cloud_admin
 prod_nodepool_user: nodepool
 prod_nodepool_project: nodepool
+
+controlplane_network_name: "control-plane"
+nodepool_network_name: "nodepool"
+controlplane_network_cidr: 192.168.10.0/24
+router_name: "bonnyci-router"
+nodepool_network_cidr: 10.0.0.0/8
+external_network_name: external
 
 security_group_rules:
   - name: sg-control-plane

--- a/roles/cloud-bootstrap/tasks/hosts.yml
+++ b/roles/cloud-bootstrap/tasks/hosts.yml
@@ -6,7 +6,7 @@
     flavor: "{{ item.flavor | default(default_flavor) }}"
     image: "{{ image_uuid }}"
     key_name: "{{ item.key_name | default('default') }}"
-    network: control-plane
+    network: "{{ controlplane_network_name }}"
     auto_ip: false
     security_groups: "{{ item.security_groups }}"
   with_items: "{{ servers }}"

--- a/roles/cloud-bootstrap/tasks/keys.yml
+++ b/roles/cloud-bootstrap/tasks/keys.yml
@@ -4,9 +4,13 @@
     cloud: "{{ cloud }}"
     name: default
     public_key: "{{ default_ssh_key }}"
+    auth:
+        project_name: "{{ prod_project }}"
 
 - name: Create cideploy key pair
   os_keypair:
     cloud: "{{ cloud }}"
     name: "{{ deploy_ssh_key_name }}"
     public_key: "{{ secrets.ssh_keys.cideploy.public }}"
+    auth:
+        project_name: "{{ prod_project }}"

--- a/roles/cloud-bootstrap/tasks/network.yml
+++ b/roles/cloud-bootstrap/tasks/network.yml
@@ -2,7 +2,7 @@
 - name: Create control-plane network
   os_network:
     cloud: "{{ cloud }}"
-    name: control-plane
+    name: "{{ controlplane_network_name }}"
     project: "{{ prod_project }}"
     auth:
       project_name: "{{ prod_project }}"
@@ -11,7 +11,7 @@
 - name: Create control-plane subnet
   os_subnet:
     cloud: "{{ cloud }}"
-    name: control-plane-subnet
+    name: "{{ controlplane_network_name }}-subnet"
     network_name: "{{ control_plane_network.network.id }}"
     cidr: "{{ controlplane_network_cidr }}"
     project: "{{ prod_project }}"
@@ -22,7 +22,7 @@
 - name: Create nodepool network
   os_network:
     cloud: "{{ cloud }}"
-    name: nodepool
+    name: "{{ nodepool_network_name }}"
     shared: "{{ split_tenants }}"
     project: "{{ prod_project }}"
     auth:
@@ -32,7 +32,7 @@
 - name: Create nodepool subnet
   os_subnet:
     cloud: "{{ cloud }}"
-    name: nodepool-subnet
+    name: "{{ nodepool_network_name }}-subnet"
     network_name: "{{ nodepool_network.network.id }}"
     cidr: "{{ nodepool_network_cidr }}"
     project: "{{ prod_project }}"
@@ -43,7 +43,7 @@
 - name: Create router
   os_router:
     cloud: "{{ cloud }}"
-    name: bonnyci-router
+    name: "{{ router_name }}"
     network: "{{ external_network_name }}"
     interfaces:
         - "{{ control_plane_subnet.subnet.id }}"
@@ -85,5 +85,3 @@
     remote_ip_prefix: "{{ controlplane_network_cidr }}"
     auth:
       project_name: "{{ prod_nodepool_project }}"
-
-


### PR DESCRIPTION
This further parameterizes the provisioning variables to allow users to
provision multiple sets of BonnyCI topologies across tenants in the cloud,
without potentially hitting name collisions in shade/os_* modules.

Related-Issue: BonnyCI/projman#157

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>