### PR TITLE
Manually install Github3.py from nodepool element as well

### DIFF
--- a/roles/nodepool/files/etc/nodepool/elements/bonnyci-nodepool/install.d/90-zuul-cloner
+++ b/roles/nodepool/files/etc/nodepool/elements/bonnyci-nodepool/install.d/90-zuul-cloner
@@ -23,4 +23,9 @@ set -e
 
 # Our use requires zuul be installed so that we can call zuul-cloner
 # The source is put in place by the source-repositories element.
+
+# We must install Github3.py manually for now, see
+# https://github.com/BonnyCI/zuul/pull/32 and
+# https://github.com/BonnyCI/zuul/pull/33
+pip2 install git+https://github.com/sigmavirus24/github3.py.git@8e9ca0056b8fed956b66dafb5398757cd8d8bed9#egg=Github3.
 pip2 install /opt/zuul/


### PR DESCRIPTION
This has been removed from our zuul requirements and manually installed
via ansible, until a new upstream release contains a commit we need.

We also need to install it manually when building nodepool images as it
no longer gets pulled in via requirements there, either.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>