### PR TITLE
ansible-runner: Use the correct pip

### DIFF
--- a/roles/ansible-runner/files/usr/local/bin/ansible-runner
+++ b/roles/ansible-runner/files/usr/local/bin/ansible-runner
@@ -26,13 +26,14 @@ timestamp=$(date +%Y%m%d%H%M%S)
 logfile="/var/www/html/cron-logs/$env/ansible_${playbook}_current.log"
 dst_logfile="/var/www/html/cron-logs/$env/ansible_${playbook}_${timestamp}.log"
 
-cd /opt/source/$env
-sudo pip install -U -r requirements.txt
 trap "cp $logfile $dst_logfile; rm -f /var/www/html/cron-logs/$env/ansible_${playbook}_latest.log; ln -s $dst_logfile /var/www/html/cron-logs/$env/ansible_${playbook}_latest.log" EXIT
 
 date 2>&1 | tee $logfile
 basename "$logfile" 2>&1 | tee -a $logfile
+cd /opt/source/$env 2>&1 | tee -a $logfile
 git pull 2>&1 | tee -a $logfile
+sudo /opt/ansible/bin/pip install -U -r requirements.txt 2>&1 | tee -a $logfile
+
 args="$@"
 if [ -n "$ANSIBLE_SSH_USER" ]; then
     args="$args -e ansible_ssh_user=$ANSIBLE_SSH_USER"


### PR DESCRIPTION
This currently calls the system pip to install requirements,
instead of installing them into the ansible venv.  I think
we somehow have not hit this because the venv in production
already had dependencies installed into it at one point in
the past.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>