### PR TITLE
Use ansible's uri module for web test instead of curl

### DIFF
--- a/tests/validate-ci.yml
+++ b/tests/validate-ci.yml
@@ -17,14 +17,9 @@
 - name: Validate zuul status
   hosts: zuul
   tasks:
-    - name: install curl
-      become: true
-      package:
-        name: curl
-        state: installed
-
     - name: zuul webapp is running
-      shell: curl --fail localhost:8001/status.json
+      uri:
+        url: http://localhost:8001/status.json
 
     - name: gearman services are running
       shell: netstat -antlp | grep 4730


### PR DESCRIPTION
Instead of installing curl and executing it from a shell use ansible's
URI module to test that zuul is up and running. This has the added
benefit that the request will timeout in 30seconds if it doesn't
succeed.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>