### PR TITLE
Don't add integration key file to config if no data

### DIFF
--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -33,5 +33,5 @@ zuul_connections:
     driver: github
     api_token: "{{ secrets.zuul_github_api_key | default('') }}"
     integration_id: "{{ secrets.zuul_github_integration_id | default('') }}"
-    integration_key: "{{ zuul_github_integration_key_file }}"
+    integration_key: "{{ secrets.zuul_github_integration_key_content | default(False) | ternary(zuul_github_integration_key_file, '') }}"
     webhook_token: "{{ secrets.zuul_github_webhook_token | default('') }}"

--- a/roles/zuul/tasks/main.yml
+++ b/roles/zuul/tasks/main.yml
@@ -54,7 +54,7 @@
     owner: zuul
     group: zuul
     mode: 0400
-  when: secrets.zuul_github_integration_key_content is defined
+  when: secrets.zuul_github_integration_key_content | default(False)
 
 - name: Install zuul config
   template:


### PR DESCRIPTION
If there is no integration key contents defined in secrets we shouldn't
add a non-existant file to the zuul config. This is causing an error in
the github connection that is crashing the main thread of zuul.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>