### PR TITLE
Update bastion jump scripts for different environments

### DIFF
--- a/inventory/group_vars/contra-sjc
+++ b/inventory/group_vars/contra-sjc
@@ -35,3 +35,5 @@ nodepool_zmq_publishers:
 
 zuul_gearman_server: zuul.bonnyci-internal.portbleu.com
 zuul_logs_url: http://logs.bonnyci.com
+
+dns_subdomain: bonnyci-internal.portbleu.com

--- a/inventory/group_vars/opentech-sjc
+++ b/inventory/group_vars/opentech-sjc
@@ -35,3 +35,5 @@ nodepool_zmq_publishers:
 
 zuul_gearman_server: zuul.internal.opentechsjc.bonnyci.org
 zuul_logs_url: http://logs.opentechsjc.bonnyci.org
+
+dns_subdomain: internal.opentechsjc.bonnyci.org

--- a/roles/bastion/defaults/main.yml
+++ b/roles/bastion/defaults/main.yml
@@ -1,3 +1,5 @@
+dns_subdomain: bonnyci.local
+
 bastion_users:
   - adam_g
   - clint

--- a/roles/bastion/templates/usr/local/bin/jump
+++ b/roles/bastion/templates/usr/local/bin/jump
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-sudo -i -u cideploy ssh ubuntu@{{ item }}.bonnyci-internal.portbleu.com
+sudo -i -u cideploy ssh ubuntu@{{ item }}.{{ dns_subdomain }}


### PR DESCRIPTION
Adds a dns_subdomain variable to bastion to specify the subdomain
the nodes will be using, and customizes the jump scripts accordingly.

Related-Issue: BonnyCI/projman#151
Signed-off-by: Adam Gandelman <adamg@ubuntu.com>