### PR TITLE
Ensure ansible-runner source checkout is owned by correct user

### DIFF
--- a/roles/ansible-runner/tasks/main.yml
+++ b/roles/ansible-runner/tasks/main.yml
@@ -81,6 +81,12 @@
     dest: "/opt/source/{{ ansible_runner_job }}"
     update: true
 
+- name: Ensure source ownership
+  file:
+    dest: "/opt/source/{{ ansible_runner_job }}"
+    owner: "{{ ansible_runner_user }}"
+    recurse: yes
+
 - name: Check for playbook deps
   stat:
     path: "/opt/source/{{ ansible_runner_job }}/requirements.txt"


### PR DESCRIPTION
While running bastion.yml, we pull down the initial checkout
of the ansible-runner repo for each environment. The ansible-runner
script is expected to be able to update this repo.   This works for
the system-ansible runner, which is run by root, but fails for the
cideploy users.  This adds a task to make sure each is owned correctly.

Related-Issue: BonnyCI/projman#151
Closes-Issue: BonnyCI/projman#169

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>