### PR TITLE
Allow setting the nodepool git url

### DIFF
--- a/roles/nodepool/defaults/main.yml
+++ b/roles/nodepool/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+nodepool_git_repo_url: https://git.openstack.org/openstack-infra/nodepool
 nodepool_git_version: master
 
 nodepool_mysql_host: localhost

--- a/roles/nodepool/meta/main.yml
+++ b/roles/nodepool/meta/main.yml
@@ -6,6 +6,6 @@ dependencies:
       - name: diskimage-builder
         state: latest
       - name: statsd
-    python_app_git_repo: https://git.openstack.org/openstack-infra/nodepool
+    python_app_git_repo: "{{ nodepool_git_repo_url }}"
     python_app_git_version: "{{ nodepool_git_version }}"
     python_app_notify: Restart nodepool


### PR DESCRIPTION
For development and maybe eventually for production it's useful to be
able to change the URL that git is cloning from.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>