### PR TITLE
Add bastion.vagrant to the vagrant group

### DIFF
--- a/inventory/vagrant
+++ b/inventory/vagrant
@@ -23,6 +23,7 @@ logs.vagrant
 logs.vagrant
 
 [vagrant]
+bastion.vagrant
 nodepool.vagrant
 zuul.vagrant
 merger.vagrant


### PR DESCRIPTION
The vagrant group_vars should be used by the vagrant bastion, most notably
disabling datadog and preventing the datadog callback plugin from being
installed.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>