### PR TITLE
Add a when conditional to python app dependencies

### DIFF
--- a/roles/python-app/tasks/main.yml
+++ b/roles/python-app/tasks/main.yml
@@ -35,6 +35,7 @@
     virtualenv: "{{ python_app_venv_path }}/{{ name }}"
     state: "{{ item.state | default(omit) }}"
   with_items: "{{ python_app_pipdeps }}"
+  when: "{{ item.when | default(True) }}"
 
 - name: Install application
   pip:


### PR DESCRIPTION
Particularly to support zuul v3 we are going to need a way to
conditionally install app dependencies, so add a when condition to the
list.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>