### PR TITLE
Correct path to tests/files/validate-ci.yml

### DIFF
--- a/tools/vagrant-run-ansible.sh
+++ b/tools/vagrant-run-ansible.sh
@@ -3,4 +3,4 @@
 export ANSIBLE_CONFIG=/vagrant/ansible.cfg
 export ANSIBLE_INVENTORY=/vagrant/inventory/vagrant
 /opt/ansible/bin/ansible-playbook -v -e @/vagrant/secrets.yml -e ansible_user=ubuntu --skip-tags monitoring,letsencrypt /vagrant/install-ci.yml "$@"
-/opt/ansible/bin/ansible-playbook -v -e @/vagrant/secrets.yml -e ansible_user=ubuntu /vagrant/tests/validate-ci.yml "$@"
+/opt/ansible/bin/ansible-playbook -v -e @/vagrant/secrets.yml -e ansible_user=ubuntu /vagrant/tests/files/validate-ci.yml "$@"


### PR DESCRIPTION
After validate-ci.yml was moved from tests/validate-ci.yml to
tests/files/validate-ci.yml, all references except one were updated.
Now, tools/vagrant-run-ansible.sh points to the correct path.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>