### PR TITLE
Remove shellcheck exclude from test-shellcheck.sh

### DIFF
--- a/.bonnyci/run.sh
+++ b/.bonnyci/run.sh
@@ -4,6 +4,7 @@ venv_dir=$(mktemp -d)
 trap 'rm -rf $venv_dir' EXIT
 
 virtualenv "$venv_dir"
+# shellcheck disable=1090
 source "$venv_dir"/bin/activate
 
 # Install all requirements for tests to run

--- a/tests/test-hoist-ansible.sh
+++ b/tests/test-hoist-ansible.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -ex
 
 echo "Running hoist ansible syntax test"
+# shellcheck disable=2046
 ansible-playbook -i tests/files/test-inventory --syntax-check $(find . tests -maxdepth 1 -type f -name \*.yml -not -name .travis.yml)
 
 echo "Running hoist ansible deployment test"

--- a/tests/test-shellcheck.sh
+++ b/tests/test-shellcheck.sh
@@ -4,6 +4,9 @@ sudo apt-get install -y shellcheck
 
 echo -n "Testing shell linter..."
 
-find . -name '*.sh' -print0 | xargs -n1 -0 shellcheck -s bash -e SC2046
+if ! find . -name '*.sh' -print0 | xargs -n1 -0 shellcheck -s bash; then
+    echo "ERROR! :("
+    exit 1
+fi
 
 echo "OK! :)"


### PR DESCRIPTION
Previously, we were excluding shellcheck rule 2046 in
tests/test-shellcheck.sh, rather than only excluding it for the line
that was causing the issue (tests/test-hoist-ansible.sh line 4). Now,
the exclude has been removed from test-shellcheck.sh.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>