### PR TITLE
Add tools/vagrant-deploy.sh

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,7 +83,6 @@ Vagrant.configure(2) do |config|
 
     zuul.trigger.after [:up, :provision] do
       run "vagrant ssh bastion -c 'sudo -i -u cideploy ssh -o StrictHostKeyChecking=no ubuntu@zuul.vagrant true'"
-      run "vagrant ssh bastion -c 'sudo -i -u cideploy /vagrant/tools/vagrant-run-ansible.sh --limit zuul'"
     end
 
     zuul.trigger.after :destroy do
@@ -105,7 +104,6 @@ Vagrant.configure(2) do |config|
 
     nodepool.trigger.after [:up, :provision] do
       run "vagrant ssh bastion -c 'sudo -i -u cideploy ssh -o StrictHostKeyChecking=no ubuntu@nodepool.vagrant true'"
-      run "vagrant ssh bastion -c 'sudo -i -u cideploy /vagrant/tools/vagrant-run-ansible.sh --limit nodepool'"
     end
 
     nodepool.trigger.after :destroy do
@@ -127,7 +125,6 @@ Vagrant.configure(2) do |config|
 
     logs.trigger.after [:up, :provision] do
       run "vagrant ssh bastion -c 'sudo -i -u cideploy ssh -o StrictHostKeyChecking=no ubuntu@logs.vagrant true'"
-      run "vagrant ssh bastion -c 'sudo -i -u cideploy /vagrant/tools/vagrant-run-ansible.sh --limit log'"
     end
 
     logs.trigger.after :destroy do
@@ -149,7 +146,6 @@ Vagrant.configure(2) do |config|
 
     merger.trigger.after [:up, :provision] do
       run "vagrant ssh bastion -c 'sudo -i -u cideploy ssh -o StrictHostKeyChecking=no ubuntu@merger.vagrant true'"
-      run "vagrant ssh bastion -c 'sudo -i -u cideploy /vagrant/tools/vagrant-run-ansible.sh --limit mergers'"
     end
 
     merger.trigger.after :destroy do
@@ -172,7 +168,6 @@ Vagrant.configure(2) do |config|
 
     elk.trigger.after [:up, :provision] do
       run "vagrant ssh bastion -c 'sudo -i -u cideploy ssh -o StrictHostKeyChecking=no ubuntu@elk.vagrant true'"
-      run "vagrant ssh bastion -c 'sudo -i -u cideploy /vagrant/tools/vagrant-run-ansible.sh --limit monitoring'"
     end
 
     elk.trigger.after :destroy do

--- a/tools/vagrant-deploy.sh
+++ b/tools/vagrant-deploy.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+vagrant up
+vagrant ssh bastion -c 'sudo -i -u cideploy ANSIBLE_CONFIG=/vagrant/ansible.cfg /opt/ansible/bin/ansible-playbook -i /vagrant/inventory/vagrant -v -e @/vagrant/secrets.yml -e ansible_user=ubuntu --skip-tags monitoring,letsencrypt /vagrant/install-ci.yml /vagrant/tests/files/validate-ci.yml "$@"'

--- a/tools/vagrant-run-ansible.sh
+++ b/tools/vagrant-run-ansible.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-export ANSIBLE_CONFIG=/vagrant/ansible.cfg
-export ANSIBLE_INVENTORY=/vagrant/inventory/vagrant
-/opt/ansible/bin/ansible-playbook -v -e @/vagrant/secrets.yml -e ansible_user=ubuntu --skip-tags monitoring,letsencrypt /vagrant/install-ci.yml "$@"
-/opt/ansible/bin/ansible-playbook -v -e @/vagrant/secrets.yml -e ansible_user=ubuntu /vagrant/tests/validate-ci.yml "$@"


### PR DESCRIPTION
Previously, vagrant deployments were failing because of an issue with
validate-ci.yml getting run before all of the nodes had been deployed.

To address this, we now have split the deploy steps into running the
ansible deployment, and then running the validation playbook. This can
be accomplished in one step by running the new tools/vagrant-deploy.sh
script.

Related-Issue: BonnyCI/projman#172
Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>