### PR TITLE
Fix quartermaster service's working directory

### DIFF
--- a/roles/quartermaster/templates/etc/systemd/system/quartermaster.service
+++ b/roles/quartermaster/templates/etc/systemd/system/quartermaster.service
@@ -7,6 +7,7 @@ Type=simple
 User={{ quartermaster_user }}
 Group={{ quartermaster_group }}
 ExecStart={{ quartermaster_venv_dir }}/bin/errbot -c {{ quartermaster_config_dir }}/config.py
+WorkingDirectory={{ quartermaster_home_dir }}
 
 [Install]
 DefaultInstance=quartermaster


### PR DESCRIPTION
Currently, the working directory for quartermaster is whatever
systemd says it is. It would be nice for plugins to be able to use
relative paths, so they don't need knowledge of where they are
installed. This changes the systemd service file to use the
quartermaster user's homedir as the working dir for the bot.

Signed-off-by: Bradon Kanyid <bradon@kanyid.org>