### PR TITLE
Open up nodepool default security group

### DIFF
--- a/roles/cloud-bootstrap/tasks/network.yml
+++ b/roles/cloud-bootstrap/tasks/network.yml
@@ -75,13 +75,13 @@
     - "{{ security_group_rules }}"
     -  "rules"
 
-- name: Create nodepool SSH security group rule
+- name: Ensure nodepool default security group is permissive
   os_security_group_rule:
     cloud: "{{ cloud }}"
     security_group: "default"
     protocol: "tcp"
-    port_range_min: "22"
-    port_range_max: "22"
+    port_range_min: "1"
+    port_range_max: "65535"
     remote_ip_prefix: "{{ controlplane_network_cidr }}"
     auth:
       project_name: "{{ prod_nodepool_project }}"


### PR DESCRIPTION
The original spec only allowed SSh through to the nodepool slaves, which blocks
the telnet console ports.  This opens it up so at least bonnyci admins have
access.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>