### PR TITLE
Grant prod_admin_user the admin role on individual user projects

### DIFF
--- a/roles/cloud-bootstrap/tasks/accounts.yml
+++ b/roles/cloud-bootstrap/tasks/accounts.yml
@@ -42,6 +42,14 @@
     role: "{{ prod_member_role }}"
   with_items: "{{ users }}"
 
+- name: Grant prod_admin_user role on user project
+  os_user_role:
+    cloud: "{{ cloud }}"
+    project: "{{ item.username }}"
+    user: "{{ prod_admin_user }}"
+    role: "{{ prod_admin_role }}"
+  with_items: "{{ users }}"
+
 - name: Add all users to prod group
   os_user_group:
     cloud: "{{ cloud }}"


### PR DESCRIPTION
This grants the prod_admin_user (cloud_admin) the admin role on individual
user projects. This is useful as it gives an admin visibility into the
resources used by each non-admin, which is important for auditting what
resourcess are in use where.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>