### PR TITLE
Update test inventory

### DIFF
--- a/roles/bastion/tasks/main.yml
+++ b/roles/bastion/tasks/main.yml
@@ -69,7 +69,7 @@
     owner: "{{ item }}"
     group: "{{ item }}"
     mode: 0600
-  when: secrets.ssh_keys.{{ item }}.private is defined
+  when: item in secrets.ssh_keys and 'private' in secrets.ssh_keys[item]
   with_items: "{{ bastion_users }}"
 
 - name: Install SSH public key to ~/.ssh/id_rsa.pub
@@ -79,7 +79,7 @@
     owner: "{{ item }}"
     group: "{{ item }}"
     mode: 0644
-  when: secrets.ssh_keys.{{ item }}.public is defined
+  when: item in secrets.ssh_keys and 'public' in secrets.ssh_keys[item]
   with_items: "{{ bastion_users }}"
 
 - name: Copy cideploy's private ssh key to /root/.ssh for GHE access

--- a/tests/files/test-inventory
+++ b/tests/files/test-inventory
@@ -1,4 +1,2 @@
-test-bastion ansible_ssh_host=127.0.0.1 ansible_ssh_user=ubuntu
-
 [bastion]
 test-bastion


### PR DESCRIPTION
The new ansible 2.2.0 doesn't like having an ungrouped host.
Update the test inventory to avoid the bug.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>