### PR TITLE
 Slice up provisioning to support multiple zuul environments per …

### DIFF
--- a/create-cloud-resources.yml
+++ b/create-cloud-resources.yml
@@ -38,45 +38,77 @@
         - username: rattboi
           email: bradon.kanyid@ibm.com
           isadmin: False
-      servers:
+      common_servers:
         - name: bastion
           floating_ip_address: 169.44.171.83
           security_groups:
-            - sg-control-plane
+            - sg-common
             - sg-http-https
             - sg-ssh
         - name: elk
           floating_ip_address: 169.44.171.88
           flavor: m1.xlarge
           security_groups:
-            - sg-control-plane
+            - sg-common
             - sg-http-https
           key_name: "{{ deploy_ssh_key_name }}"
         - name: logs
           floating_ip_address: 169.44.171.84
           security_groups:
-            - sg-control-plane
-            - sg-http-https
-          key_name: "{{ deploy_ssh_key_name }}"
-        - name: nodepool
-          security_groups:
-            - sg-control-plane
-          key_name: "{{ deploy_ssh_key_name }}"
-        - name: merger01
-          security_groups:
-            - sg-control-plane
-            - sg-zuul-merger
-          key_name: "{{ deploy_ssh_key_name }}"
-        - name: zuul
-          floating_ip_address: 169.44.171.85
-          security_groups:
-            - sg-control-plane
+            - sg-common
             - sg-http-https
           key_name: "{{ deploy_ssh_key_name }}"
         - name: bot
           floating_ip_address: 169.44.171.92
           flavor: m1.tiny
           security_groups:
-            - sg-control-plane
+            - sg-common
             - sg-http-https
           key_name: "{{ deploy_ssh_key_name }}"
+      environments:
+        - name: v2
+          dns_subdomain: internal.opentechsjc.bonnyci.org
+          controlplane_network_name: control-plane
+          controlplane_cidr: 192.168.10.0/24
+          controlplane_secgroup_name: sg-control-plane
+          zuulmerger_secgroup_name: sg-zuul-merger
+          nodepool_network_name: nodepool
+          nodepool_cidr: 10.0.0.0/8
+          servers:
+          - name: nodepool
+            security_groups:
+              - sg-control-plane
+            key_name: "{{ deploy_ssh_key_name }}"
+          - name: merger01
+            security_groups:
+              - sg-control-plane
+              - sg-zuul-merger
+            key_name: "{{ deploy_ssh_key_name }}"
+          - name: zuul
+            floating_ip_address: 169.44.171.85
+            security_groups:
+              - sg-control-plane
+              - sg-http-https
+            key_name: "{{ deploy_ssh_key_name }}"
+        - name: v3
+          dns_subdomain: internal.v3.opentechsjc.bonnyci.org
+          controlplane_network_name: control-plane-v3
+          controlplane_cidr: 192.168.30.0/24
+          nodepool_network_name: nodepool-v3
+          nodepool_cidr: 172.16.30.0/24
+          servers:
+          - name: nodepool
+            security_groups:
+              - sg-control-plane-v3
+            key_name: "{{ deploy_ssh_key_name }}"
+          - name: merger01
+            security_groups:
+              - sg-control-plane-v3
+              - sg-zuul-merger-v3
+            key_name: "{{ deploy_ssh_key_name }}"
+          - name: zuul
+            floating_ip_address: 169.44.161.47
+            security_groups:
+              - sg-control-plane-v3
+              - sg-http-https
+            key_name: "{{ deploy_ssh_key_name }}"

--- a/roles/cloud-bootstrap/defaults/main.yml
+++ b/roles/cloud-bootstrap/defaults/main.yml
@@ -30,6 +30,8 @@ prod_admin_role: cloud_admin
 prod_nodepool_user: nodepool
 prod_nodepool_project: nodepool
 
+common_network_name: "ci-common"
+common_network_cidr: 192.168.5.0/24
 controlplane_network_name: "control-plane"
 nodepool_network_name: "nodepool"
 controlplane_network_cidr: 192.168.10.0/24
@@ -37,16 +39,9 @@ router_name: "bonnyci-router"
 nodepool_network_cidr: 10.0.0.0/8
 external_network_name: external
 
-security_group_rules:
-  - name: sg-control-plane
-    rules:
-      - remote_group: sg-control-plane
-        port_min: 1
-        port_max: 65535
-  - name: sg-zuul-merger
-    rules:
-      - remote_cidr: "{{ nodepool_network_cidr }}"
-        port: 8858
+common_security_group_rules:
+  - name: sg-common
+    rules: []
   - name: sg-ssh
     rules:
       - remote_cidr: 0.0.0.0/0
@@ -58,37 +53,77 @@ security_group_rules:
       - remote_cidr: 0.0.0.0/0
         port: 443
 
-servers:
+
+environment_security_group_rules:
+  - name: sg-control-plane
+    rules:
+      - remote_group: sg-control-plane
+        port_min: 1
+        port_max: 65535
+      - remote_group: sg-common
+        port: 22
+  - name: sg-zuul-merger
+    rules:
+      - remote_cidr: "{{ nodepool_network_cidr }}"
+        port: 8858
+
+ommon_servers:
   - name: bastion
-    floating_ip_network: "{{ external_network_name }}"
+    floating_ip_network: external
     security_groups:
-      - sg-control-plane
+      - sg-common
       - sg-http-https
       - sg-ssh
   - name: elk
-    floating_ip_network: "{{ external_network_name }}"
+    floating_ip_network: external
     security_groups:
-      - sg-control-plane
+      - sg-common
       - sg-http-https
     key_name: "{{ deploy_ssh_key_name }}"
   - name: logs
-    floating_ip_network: "{{ external_network_name }}"
+    floating_ip_network: external
     security_groups:
-      - sg-control-plane
+      - sg-common
       - sg-http-https
     key_name: "{{ deploy_ssh_key_name }}"
-  - name: nodepool
-    security_groups:
-      - sg-control-plane
-    key_name: "{{ deploy_ssh_key_name }}"
-  - name: merger01
-    security_groups:
-      - sg-control-plane
-      - sg-zuul-merger
-    key_name: "{{ deploy_ssh_key_name }}"
-  - name: zuul
-    floating_ip_network: "{{ external_network_name }}"
-    security_groups:
-      - sg-control-plane
-      - sg-http-https
-    key_name: "{{ deploy_ssh_key_name }}"
+
+environments:
+  - name: v2
+    controlplane_cidr: 192.168.10.0/24
+    nodepool_cidr: 10.0.0.0/24
+    servers:
+      - name: nodepool
+        security_groups:
+          - sg-control-plane
+        key_name: "{{ deploy_ssh_key_name }}"
+      - name: merger01
+        security_groups:
+          - sg-control-plane
+          - sg-zuul-merger
+        key_name: "{{ deploy_ssh_key_name }}"
+      - name: zuul
+        floating_ip_network: external
+        security_groups:
+          - sg-control-plane
+          - sg-http-https
+        key_name: "{{ deploy_ssh_key_name }}"
+
+  - name: v3
+    controlplane_cidr: 192.168.30.0/24
+    nodepool_cidr: 10.0.3.0/24
+    servers:
+      - name: nodepool
+        security_groups:
+          - sg-control-plane-v3
+        key_name: "{{ deploy_ssh_key_name }}"
+      - name: merger01
+        security_groups:
+          - sg-control-plane-v3
+          - sg-zuul-merger-v3
+        key_name: "{{ deploy_ssh_key_name }}"
+      - name: zuul
+        floating_ip_network: external
+        security_groups:
+          - sg-control-plane-v3
+          - sg-http-https
+        key_name: "{{ deploy_ssh_key_name }}"

--- a/roles/cloud-bootstrap/tasks/env_hosts.yml
+++ b/roles/cloud-bootstrap/tasks/env_hosts.yml
@@ -1,25 +1,28 @@
----
-- name: Create common hosts
+- set_fact:
+   outer_item: "{{ item }}"
+   default_dns_subdomain: "{{ item.name }}.{{ dns_subdomain }}"
+
+- set_fact:
+   subdomain: "{{ item.dns_subdomain | default(default_dns_subdomain) }}"
+
+- name: Create per-env hosts
   os_server:
     cloud: "{{ cloud }}"
-    name: "{{ item.name }}.{{ dns_subdomain }}"
+    name: "{{ item.name }}.{{ subdomain }}"
     flavor: "{{ item.flavor | default(default_flavor) }}"
     image: "{{ image_uuid }}"
     key_name: "{{ item.key_name | default('default') }}"
-    network: "{{ common_network_name }}"
+    network: "{{ outer_item.controlplane_network_name }}"
     auto_ip: false
     security_groups: "{{ item.security_groups }}"
-  with_items: "{{ common_servers }}"
+  with_items: "{{ outer_item.servers }}"
 
-- name: Associate floating IPs
+- name: Associate per-env floating IPs
   os_floating_ip:
     cloud: "{{ cloud }}"
-    server: "{{ item.name }}.{{ dns_subdomain }}"
+    server: "{{ item.name }}.{{ subdomain }}"
     network: "{{ item.floating_ip_network | default(omit) }}"
     floating_ip_address: "{{ item.floating_ip_address | default(omit) }}"
-  with_items: "{{ common_servers }}"
+  with_items: "{{ outer_item.servers}}"
   when: item.floating_ip_address is defined or item.floating_ip_network is defined
 
-- Name: Create per-env hosts
-  include: env_hosts.yml
-  with_items: "{{ environments }}"

--- a/roles/cloud-bootstrap/tasks/env_network.yml
+++ b/roles/cloud-bootstrap/tasks/env_network.yml
@@ -1,0 +1,96 @@
+- set_fact:
+   outer_item: "{{ item }}"
+   default_controlplane_network_name: "control-plane-{{ item.name }}"
+   default_nodepool_network_name: "nodepool-{{ item.name }}"
+   default_secgroup_control_plane_name: "sg-control-plane-{{ item.name }}"
+   default_secgroup_merger_name: "sg-zuul-merger-{{ item.name }}"
+
+- set_fact:
+   cp_network_name: "{{ item.controlplane_network_name | default(default_controlplane_network_name) }}"
+   np_network_name: "{{ item.nodepool_network_name | default(default_nodepool_network_name) }}"
+   cp_secgroup_name: "{{ item.controlplane_secgroup_name | default(default_secgroup_control_plane_name) }}"
+   zm_secgroup_name: "{{ item.zuulmerger_secgroup_name | default(default_secgroup_merger_name) }}"
+
+- name: Create per-env control-plane network
+  os_network :
+    cloud: "{{ cloud }}"
+    name: "{{ cp_network_name }}"
+    project:  "{{ prod_project }}"
+    auth:
+      project_name: "{{ prod_project }}"
+  register:  control_plane_network
+
+- name: Create per-env control-plane subnet
+  os_subnet:
+    cloud: "{{ cloud }}"
+    name: "{{ cp_network_name }}-subnet"
+    network_name: "{{ control_plane_network.network.id }}"
+    cidr: "{{ outer_item.controlplane_cidr }}"
+    project: "{{ prod_project }}"
+    auth:
+      project_name: "{{ prod_project }}"
+  register: control_plane_subnet
+
+- name: Create per-env nodepool network
+  os_network :
+    cloud: "{{ cloud }}"
+    name: "{{ np_network_name }}"
+    project:  "{{ prod_project }}"
+    shared: "{{ split_tenants }}"
+    auth:
+      project_name: "{{ prod_project }}"
+  register: nodepool_network
+
+- name: Create per-env nodepool subnet
+  os_subnet:
+    cloud: "{{ cloud }}"
+    name: "{{ np_network_name }}-subnet"
+    network_name: "{{ nodepool_network.network.id }}"
+    cidr: "{{ outer_item.nodepool_cidr }}"
+    project: "{{ prod_project }}"
+    auth:
+      project_name: "{{ prod_project }}"
+  register: nodepool_subnet
+
+- name: Create per-env control-plane secgroup
+  os_security_group:
+    cloud: "{{ cloud }}"
+    name: "{{ cp_secgroup_name }}"
+    auth:
+       project_name: "{{ prod_project }}"
+
+- name: Create per-env merger secgroup
+  os_security_group:
+    cloud: "{{ cloud }}"
+    name: "{{ zm_secgroup_name }}"
+    auth:
+       project_name: "{{ prod_project }}"
+
+- name: Create per-env secgroup rules
+  os_security_group_rule:
+    cloud: "{{ cloud }}"
+    security_group: "{{ item.group }}"
+    protocol: tcp
+    port_range_min: "{{ item.port_min }}"
+    port_range_max: "{{ item.port_max }}"
+    remote_group: "{{ item.remote_group | default(omit) }}"
+    remote_ip_prefix: "{{ item.remote_ip_prefix | default(omit) }}"
+    auth:
+       project_name: "{{ prod_project }}"
+  with_items:
+     - group: "{{ cp_secgroup_name }}"
+       port_min: 1
+       port_max: 65535
+       remote_group: "{{ cp_secgroup_name }}"
+     - group: "{{ cp_secgroup_name }}"
+       port_min: 22
+       port_max: 22
+       remote_group: "sg-common"
+     - group: "{{ cp_secgroup_name }}"
+       port_min: 1
+       port_max: 65535
+       remote_group: "{{ cp_secgroup_name }}"
+     - group: "{{ zm_secgroup_name }}"
+       port_min: 8858
+       port_max: 8858
+       remote_ip_prefix: "{{ outer_item.nodepool_cidr }}"

--- a/roles/cloud-bootstrap/tasks/network.yml
+++ b/roles/cloud-bootstrap/tasks/network.yml
@@ -1,64 +1,31 @@
 ---
-- name: Create control-plane network
+- name: Create common network
   os_network:
     cloud: "{{ cloud }}"
-    name: "{{ controlplane_network_name }}"
+    name: "{{ common_network_name }}"
     project: "{{ prod_project }}"
     auth:
       project_name: "{{ prod_project }}"
-  register: control_plane_network
+  register: common_network
 
-- name: Create control-plane subnet
+- name: Create common subnet
   os_subnet:
     cloud: "{{ cloud }}"
-    name: "{{ controlplane_network_name }}-subnet"
-    network_name: "{{ control_plane_network.network.id }}"
-    cidr: "{{ controlplane_network_cidr }}"
+    name: "{{ common_network_name }}-subnet"
+    network_name: "{{ common_network.id }}"
+    cidr: "{{ common_network_cidr }}"
     project: "{{ prod_project }}"
     auth:
       project_name: "{{ prod_project }}"
-  register: control_plane_subnet
+  register: common_subnet
 
-- name: Create nodepool network
-  os_network:
-    cloud: "{{ cloud }}"
-    name: "{{ nodepool_network_name }}"
-    shared: "{{ split_tenants }}"
-    project: "{{ prod_project }}"
-    auth:
-      project_name: "{{ prod_project }}"
-  register: nodepool_network
-
-- name: Create nodepool subnet
-  os_subnet:
-    cloud: "{{ cloud }}"
-    name: "{{ nodepool_network_name }}-subnet"
-    network_name: "{{ nodepool_network.network.id }}"
-    cidr: "{{ nodepool_network_cidr }}"
-    project: "{{ prod_project }}"
-    auth:
-      project_name: "{{ prod_project }}"
-  register: nodepool_subnet
-
-- name: Create router
-  os_router:
-    cloud: "{{ cloud }}"
-    name: "{{ router_name }}"
-    network: "{{ external_network_name }}"
-    interfaces:
-        - "{{ control_plane_subnet.subnet.id }}"
-        - "{{ nodepool_subnet.subnet.id }}"
-    project: "{{ prod_project }}"
-    auth:
-      project_name: "{{ prod_project }}"
-
-- name: Create security groups
+- name: Create common security groups
   os_security_group:
     cloud: "{{ cloud }}"
     name: "{{ item.name }}"
     auth:
       project_name: "{{ prod_project }}"
-  with_items: "{{ security_group_rules }}"
+  with_items: "{{ common_security_group_rules }}"
 
 - name: Create security group rules
   os_security_group_rule:
@@ -72,8 +39,19 @@
     auth:
       project_name: "{{ prod_project }}"
   with_subelements:
-    - "{{ security_group_rules }}"
+    - "{{ common_security_group_rules }}"
     -  "rules"
+
+- include: env_network.yml
+  with_items: "{{ environments }}"
+
+- name: Create router
+  os_router:
+    cloud: "{{ cloud }}"
+    name: "{{ router_name }}"
+    network: "{{ external_network_name }}"
+    interfaces:
+        - "{{ common_subnet.subnet.id }}"
 
 - name: Ensure nodepool default security group is permissive
   os_security_group_rule:
@@ -85,3 +63,4 @@
     remote_ip_prefix: "{{ controlplane_network_cidr }}"
     auth:
       project_name: "{{ prod_nodepool_project }}"
+  when: "{{ split_tenants | bool }}"


### PR DESCRIPTION
…bastion

This creates a common network and puts services that are shared among
environments on it, including the bastion.

It then moves per-environment hosts in to an 'environments' list that
will allow easily expanding our infra to include many zuul environments.

A reasonable set of defaults are used so that individual users can spin up
similar environments in their tenant space.  Those may be overriden to supply
site-specific values for production.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>