### PR TITLE
Allow multiple cron jobs per ansible-runner task

### DIFF
--- a/bastion.yml
+++ b/bastion.yml
@@ -32,17 +32,4 @@
             - notifempty
       when: secrets is defined
     - role: ansible-runner
-      ansible_runner_job: system-ansible
-      ansible_playbook: bastion.yml
-      ansible_inventory: "/opt/source/system-ansible/inventory/{{ ci_inventory }}"
-      ansible_runner_user: root
-      ansible_runner_repo: "{{ hoist_repo }}"
-      ansible_runner_minute: "*/15"
-    - role: ansible-runner
-      ansible_playbook: install-ci.yml
-      ansible_inventory: "/opt/source/cideploy/inventory/{{ ci_inventory }}"
-      ansible_runner_job: cideploy
-      ansible_runner_user: cideploy
-      ansible_remote_user: ubuntu
-      ansible_runner_repo: "{{ hoist_repo }}"
       ansible_runner_minute: "*/15"

--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -5,8 +5,6 @@ bonnyci_logs_scp_user: zuul
 
 filebeat_output_logstash_enabled: true
 
-hoist_repo: https://github.com/BonnyCI/hoist.git
-
 letsencrypt_account_key_content: "{{ secrets.letsencrypt.account_key }}"
 letsencrypt_csr_dn:
   C: AU

--- a/inventory/group_vars/vagrant
+++ b/inventory/group_vars/vagrant
@@ -13,8 +13,6 @@ elasticsearch_jvm_heap_size: 250m
 filebeat_output_logstash_hosts:
   - elk.vagrant:5044
 
-hoist_repo: /vagrant/.git
-
 nodepool_providers:
   - name: cicloud
     cloud: cicloud

--- a/inventory/host_vars/allinone
+++ b/inventory/host_vars/allinone
@@ -1,8 +1,19 @@
-ci_inventory: allinone
-
 zookeeper_myid: 1
 
 zuul_components:
   - zuul-launcher
   - zuul-merger
   - zuul-server
+
+ansible_runner_tasks:
+    - name: system-ansible
+      playbook: bastion.yml
+      inventory: allinone
+      repo: http://github.com/BonnyCI/hoist.git
+      user: root
+
+    - name: cideploy
+      playbook: install-ci.yml
+      inventory: allinone
+      repo: http://github.com/BonnyCI/hoist.git
+      user: cideploy

--- a/inventory/host_vars/bastion.opentechsjc.bonnyci.org
+++ b/inventory/host_vars/bastion.opentechsjc.bonnyci.org
@@ -1,2 +1,14 @@
-ci_inventory: opentech-sjc
+ansible_runner_tasks:
+    - name: system-ansible
+      playbook: bastion.yml
+      inventory: opentech-sjc
+      repo: http://github.com/BonnyCI/hoist.git
+      user: root
+
+    - name: cideploy
+      playbook: install-ci.yml
+      inventory: opentech-sjc
+      repo: http://github.com/BonnyCI/hoist.git
+      user: cideploy
+
 dns_subdomain: internal.opentechsjc.bonnyci.org

--- a/inventory/host_vars/bastion.vagrant
+++ b/inventory/host_vars/bastion.vagrant
@@ -1,4 +1,15 @@
 bastion_clouds:
   - cicloud
 
-ci_inventory: vagrant
+ansible_runner_tasks:
+    - name: system-ansible
+      playbook: bastion.yml
+      inventory: vagrant
+      repo: /vagrant/.git
+      user: root
+
+    - name: cideploy
+      playbook: install-ci.yml
+      inventory: vagrant
+      repo: /vagrant/.git
+      user: cideploy

--- a/roles/ansible-runner/defaults/main.yml
+++ b/roles/ansible-runner/defaults/main.yml
@@ -2,3 +2,23 @@ ansible_runner_user: root
 ansible_runner_secrets_path: /etc/secrets.yml
 ansible_runner_virtualenv: /opt/ansible
 datadog_callback_url: https://raw.githubusercontent.com/DataDog/ansible-datadog-callback/master/datadog_callback.py
+
+# Example:
+# ansible_runner_tasks:
+#    - name: common-ansible
+#      playbook: common.yml
+#      inventory: opentech-sjc-common
+#      repo: http://github.com/BonnyCI/hoist.git
+#      user: root
+#    - name: cideploy-v2
+#      playbook: install-ci.yml
+#      inventory: opentech-sjc-v2
+#      repo: http://github.com/BonnyCI/hoist.git
+#      user: cideploy
+#    - name: cideploy-v3
+#      playbook: install-ci.yml
+#      inventory: opentech-sjc-v3
+#      repo: http://github.com/BonnyCI/hoist.git
+#      user: cideploy
+
+ansible_runner_tasks: []

--- a/roles/ansible-runner/tasks/main.yml
+++ b/roles/ansible-runner/tasks/main.yml
@@ -52,13 +52,6 @@
   tags:
     - datadog
 
-- name: Install config file
-  template:
-    src: ansible-runner-config
-    dest: /etc/default/{{ ansible_runner_job }}
-    mode: 0600
-    owner: "{{ ansible_runner_user }}"
-
 - name: Install ansible-runner
   copy:
     src: usr/local/bin/ansible-runner
@@ -75,45 +68,13 @@
     owner: root
     group: root
 
-- name: Download source
-  git:
-    repo: "{{ ansible_runner_repo }}"
-    dest: "/opt/source/{{ ansible_runner_job }}"
-    update: true
-
-- name: Ensure source ownership
+- name: Ensure source dir
   file:
-    dest: "/opt/source/{{ ansible_runner_job }}"
-    owner: "{{ ansible_runner_user }}"
-    recurse: yes
-
-- name: Check for playbook deps
-  stat:
-    path: "/opt/source/{{ ansible_runner_job }}/requirements.txt"
-  register: requirements_txt
-
-- name: Install playbook deps
-  pip:
-    virtualenv: "{{ ansible_runner_virtualenv }}"
-    requirements: "/opt/source/{{ ansible_runner_job }}/requirements.txt"
-  when: requirements_txt.stat.exists
-
-- name: Ensure cron log path
-  file:
+    path: /opt/source
     state: directory
-    path: "/var/www/html/cron-logs/{{ ansible_runner_job }}"
     mode: 0755
-    owner: "{{ ansible_runner_user }}"
-    group: www-data
+    owner: root
+    group: root
 
-- include: secret-file.yml
-  secret_file_type: secrets
-  secret_file_path: "{{ ansible_runner_secrets_path }}"
-  secret_file_user: "{{ ansible_runner_user }}"
-
-- name: Add ansible-runner cron job
-  cron:
-    name: "ansible-runner deploy {{ ansible_runner_job }}"
-    minute: "{{ ansible_runner_minute | default(omit) }}"
-    user: "{{ ansible_runner_user }}"
-    job: "/usr/local/bin/ansible-runner {{ ansible_runner_job }} -e @{{ ansible_runner_secrets_path }}"
+- include: runner.yml
+  with_items: "{{ ansible_runner_tasks }}"

--- a/roles/ansible-runner/tasks/runner.yml
+++ b/roles/ansible-runner/tasks/runner.yml
@@ -1,0 +1,49 @@
+- name: Install config file
+  template:
+    src: ansible-runner-config
+    dest: /etc/default/{{ item.name }}
+    mode: 0600
+    owner: "{{ item.user }}"
+
+- name: Download source
+  git:
+    repo: "{{ item.repo }}"
+    dest: "/opt/source/{{ item.name }}"
+    update: true
+
+- name: Ensure source ownership
+  file:
+    dest: "/opt/source/{{ item.name }}"
+    owner: "{{ item.user }}"
+    recurse: yes
+
+- name: Check for playbook deps
+  stat:
+    path: "/opt/source/{{ item.name }}/requirements.txt"
+  register: requirements_txt
+
+- name: Install playbook deps
+  pip:
+    virtualenv: "{{ ansible_runner_virtualenv }}"
+    requirements: "/opt/source/{{ item.name }}/requirements.txt"
+  when: requirements_txt.stat.exists
+
+- include: secret-file.yml
+  secret_file_type: secrets
+  secret_file_path: "{{ ansible_runner_secrets_path }}"
+  secret_file_user: "{{ item.user }}"
+
+- name: Ensure cron log path
+  file:
+    state: directory
+    path: "/var/www/html/cron-logs/{{ item.name }}"
+    mode: 0755
+    owner: "{{ item.user }}"
+    group: www-data
+
+- name: Add ansible-runner cron job
+  cron:
+    name: "ansible-runner deploy {{ item.name}}"
+    minute: "{{ ansible_runner_minute | default(omit) }}"
+    user: "{{ item.user }}"
+    job: "/usr/local/bin/ansible-runner {{ item.name }} -e @{{ ansible_runner_secrets_path }}"

--- a/roles/ansible-runner/templates/ansible-runner-config
+++ b/roles/ansible-runner/templates/ansible-runner-config
@@ -1,3 +1,3 @@
-ANSIBLE_PLAYBOOK={{ ansible_playbook }}
-ANSIBLE_INVENTORY={{ ansible_inventory }}
-ANSIBLE_SSH_USER={{ ansible_remote_user | default('') }}
+ANSIBLE_PLAYBOOK={{ item.playbook }}
+ANSIBLE_INVENTORY=/opt/source/{{ item.name }}/inventory/{{ item.inventory }}
+ANSIBLE_SSH_USER={{ item.user | default('') }}


### PR DESCRIPTION
Instead of requiring multiple ansible-runner tasks at the top-level,
allow a list of jobs to passed in as a variable.  We currently do this at
the top-level play but that makes it difficult to run different sets of
jobs for different environments.  This will allow us to run many runner
jobs in production with different inventories.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>