### PR TITLE
Fix missing user + ansible_remote_user distinction

### DIFF
--- a/inventory/host_vars/allinone
+++ b/inventory/host_vars/allinone
@@ -17,3 +17,4 @@ ansible_runner_tasks:
       inventory: allinone
       repo: http://github.com/BonnyCI/hoist.git
       user: cideploy
+      ansible_remote_user: cideploy

--- a/inventory/host_vars/bastion.opentechsjc.bonnyci.org
+++ b/inventory/host_vars/bastion.opentechsjc.bonnyci.org
@@ -1,7 +1,7 @@
 ansible_runner_tasks:
     - name: system-ansible
       playbook: bastion.yml
-      inventory: opentech-sjc
+      inventory: opentech-sjc-common
       repo: http://github.com/BonnyCI/hoist.git
       user: root
 
@@ -10,11 +10,13 @@ ansible_runner_tasks:
       inventory: opentech-sjc
       repo: http://github.com/BonnyCI/hoist.git
       user: cideploy
+      ansible_remote_user: ubuntu
 
     - name: cideploy
       playbook: install-ci.yml
       inventory: opentech-sjc-v3
       repo: http://github.com/BonnyCI/hoist.git
       user: cideploy
+      ansible_remote_user: ubuntu
 
 dns_subdomain: internal.opentechsjc.bonnyci.org

--- a/inventory/host_vars/bastion.vagrant
+++ b/inventory/host_vars/bastion.vagrant
@@ -13,3 +13,4 @@ ansible_runner_tasks:
       inventory: vagrant
       repo: /vagrant/.git
       user: cideploy
+      ansible_remote_user: ubuntu

--- a/roles/ansible-runner/defaults/main.yml
+++ b/roles/ansible-runner/defaults/main.yml
@@ -15,10 +15,12 @@ datadog_callback_url: https://raw.githubusercontent.com/DataDog/ansible-datadog-
 #      inventory: opentech-sjc-v2
 #      repo: http://github.com/BonnyCI/hoist.git
 #      user: cideploy
+#      ansible_remote_user: ubuntu
 #    - name: cideploy-v3
 #      playbook: install-ci.yml
 #      inventory: opentech-sjc-v3
 #      repo: http://github.com/BonnyCI/hoist.git
 #      user: cideploy
+#      ansible_remote_user: ubuntu
 
 ansible_runner_tasks: []

--- a/roles/ansible-runner/templates/ansible-runner-config
+++ b/roles/ansible-runner/templates/ansible-runner-config
@@ -1,3 +1,3 @@
 ANSIBLE_PLAYBOOK={{ item.playbook }}
 ANSIBLE_INVENTORY=/opt/source/{{ item.name }}/inventory/{{ item.inventory }}
-ANSIBLE_SSH_USER={{ item.user | default('') }}
+ANSIBLE_SSH_USER={{ item.ansible_remote_user | default('') }}


### PR DESCRIPTION
I, Adam Gandelman, broke ansible-runner tasks in a previous commit
by not distinguishing between the local user running the task and
the remote user that is written to the tasks' /etc/default/ config
file.

This updates it to write out based on the optional ansible_remote_user
variable.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>