### PR TITLE
Add ansible-runner task for common hosts, update name for v3

### DIFF
--- a/inventory/host_vars/bastion.opentechsjc.bonnyci.org
+++ b/inventory/host_vars/bastion.opentechsjc.bonnyci.org
@@ -5,7 +5,7 @@ ansible_runner_tasks:
       repo: http://github.com/BonnyCI/hoist.git
       user: root
 
-    - name: cideploy
+    - name: cideploy-common
       playbook: install-ci.yml
       inventory: opentech-sjc
       repo: http://github.com/BonnyCI/hoist.git
@@ -13,6 +13,13 @@ ansible_runner_tasks:
       ansible_remote_user: ubuntu
 
     - name: cideploy
+      playbook: install-ci.yml
+      inventory: opentech-sjc
+      repo: http://github.com/BonnyCI/hoist.git
+      user: cideploy
+      ansible_remote_user: ubuntu
+
+    - name: cideploy-v3
       playbook: install-ci.yml
       inventory: opentech-sjc-v3
       repo: http://github.com/BonnyCI/hoist.git


### PR DESCRIPTION
This adds an additional ansible-runner task to deploy to remote
common service hosts (logs, elk, etc).  This uses the same inventory
as the bastion task, but does not run as root.

This also updates the task name for the v3 environment.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>