### PR TITLE
Shorten the path of ssh control sockets

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,6 +7,7 @@ callback_plugins = /opt/ansible/plugins/callback:/opt/ansible/lib/python2.7/site
 
 [ssh_connection]
 pipelining = True
+control_path=%(directory)s/ansible-ssh-%%C
 
 [ara]
 # This will default the database and logs location to be inside that directory.


### PR DESCRIPTION
With the new v3 hostnames, we're exceeding the maximum path for a
socket.  Switch ansible's naming of control sockets to use %C,
which uses a hash of $host-$port-$user instead.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>