### PR TITLE
Add zuul zookeeper hosts to zuul v3 environment

### DIFF
--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -64,3 +64,5 @@ zuul_tenants:
           - bonnyci/sandbox
 
 dns_subdomain: internal.v3.opentechsjc.bonnyci.org
+zuul_zookeeper_hosts:
+  - zuul.internal.v3.opentechsjc.bonnyci.org:2181

--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -33,4 +33,5 @@ zuul_sites: {}
 
 zuul_zuul_v3: False
 
-zuul_zookeeper_hosts: "127.0.0.1:2181"
+zuul_zookeeper_hosts:
+  - "127.0.0.1:2181"

--- a/roles/zuul/templates/etc/zuul/zuul_v3.conf
+++ b/roles/zuul/templates/etc/zuul/zuul_v3.conf
@@ -26,7 +26,7 @@ url_pattern = {{ zuul_logs_url }}/{build.parameters[LOG_PATH]}
 log_config = /etc/zuul/scheduler-logging.conf
 pidfile = /var/run/zuul-scheduler/zuul-scheduler.pid
 tenant_config = /etc/zuul/tenant.yaml
-zookeeper_hosts = {{ zuul_zookeeper_hosts }}
+zookeeper_hosts = {{ zuul_zookeeper_hosts | join(",") }}
 
 [executor]
 log_config = /etc/zuul/executor-logging.conf


### PR DESCRIPTION
Zuul scheduler is failing to start in the zuul v3 environment because it
cannot contact the zookeeper instance. By default it looks for this on
localhost. We need to tell it to look at the nodepool machine.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>