### PR TITLE
Use the anne-bonny account on gerrithub

### DIFF
--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -50,7 +50,7 @@ zuul_logs_url: http://logs.bonnyci.org
 zuul_connections:
   gerrithub:
     driver: gerrit
-    user: bonnyci
+    user: anne-bonny
     server: review.gerrithub.io
     sshkey: /var/lib/zuul/.ssh/id_rsa
 


### PR DESCRIPTION
You need a real account to login to gerrithub and receive notifications.
I've added the ssh key so that anne-bonny can login.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>