### PR TITLE
Use correct host for zuul zookeeper servers

### DIFF
--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -65,4 +65,4 @@ zuul_tenants:
 
 dns_subdomain: internal.v3.opentechsjc.bonnyci.org
 zuul_zookeeper_hosts:
-  - zuul.internal.v3.opentechsjc.bonnyci.org:2181
+  - nodepool.internal.v3.opentechsjc.bonnyci.org:2181


### PR DESCRIPTION
I am an idiot.

Zookeeper is on nodepool, not zuul.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>