### PR TITLE
Specify sandbox-v3 project

### DIFF
--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -61,7 +61,7 @@ zuul_tenants:
         config-repos:
           - bonnyci/project-config
         project-repos:
-          - bonnyci/sandbox
+          - bonnyci/sandbox-v3
 
 dns_subdomain: internal.v3.opentechsjc.bonnyci.org
 zuul_zookeeper_hosts:


### PR DESCRIPTION
We probably could have reused the BonnyCI/sandbox for this, but we need
to specify the sandbox-v3 project to get it to pick up events.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>