### PR TITLE
Drop Zuul V3 multinode label, decrease min-ready, update provider

### DIFF
--- a/inventory/group_vars/opentech-sjc
+++ b/inventory/group_vars/opentech-sjc
@@ -35,6 +35,21 @@ nodepool_providers:
         private-key: /var/lib/nodepool/.ssh/id_rsa
         user-home: /home/bonnyci
         username: bonnyci
+
+nodepool_labels:
+  - name: ubuntu-xenial
+    image: ubuntu-xenial
+    min-ready: 3
+    providers:
+      - name: cicloud
+  - name: ubuntu-hoist
+    image: ubuntu-xenial
+    min-ready: 2
+    subnodes: 3
+    ready-script: subnode-ssh.sh
+    providers:
+      - name: cicloud
+
 nodepool_zmq_publishers:
   - tcp://zuul.internal.opentechsjc.bonnyci.org:8888
 

--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -28,7 +28,7 @@ nodepool_gearman_servers:
     port: 4730
 nodepool_mysql_host: zuul.internal.v3.opentechsjc.bonnyci.org
 nodepool_providers:
-  - name: cicloud
+  - name: cicloud-v3
     cloud: opentech-sjc-v3
     max-servers: 20
     networks:
@@ -36,11 +36,19 @@ nodepool_providers:
         public: True
     images:
       - name: ubuntu-xenial
-        min-ram: 2048
+        min-ram: 1026
         diskimage: ubuntu-xenial
         private-key: /var/lib/nodepool/.ssh/id_rsa
         user-home: /home/bonnyci
         username: bonnyci
+
+nodepool_labels:
+  - name: ubuntu-xenial
+    image: ubuntu-xenial
+    min-ready: 1
+    providers:
+      - name: cicloud-v3
+
 nodepool_zmq_publishers:
   - tcp://zuul.internal.v3.opentechsjc.bonnyci.org:8888
 

--- a/inventory/group_vars/production
+++ b/inventory/group_vars/production
@@ -1,20 +1,6 @@
 bonnyci_lockdown_ssh: yes
 letsencrypt_production: yes
 
-nodepool_labels:
-  - name: ubuntu-xenial
-    image: ubuntu-xenial
-    min-ready: 4
-    providers:
-      - name: cicloud
-  - name: ubuntu-hoist
-    image: ubuntu-xenial
-    min-ready: 3
-    subnodes: 3
-    ready-script: subnode-ssh.sh
-    providers:
-      - name: cicloud
-
 nodepool_statsd_enable: yes
 nodepool_use_datadog_logging: yes
 


### PR DESCRIPTION
Our cloud is running out of resources. We don't initially need any resources
for our V3 testing.  This drops the min-ready to 1, drops the multinode
label entirely and uses a smaller instance size for the slaves.

It also updates the node provider name for the V3 environment, which gets set
in slave instances' metadata and is used by nodepool to filter instances.  This
should be unique.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>