### PR TITLE
The elk host needs to open port 5044 for logstash

### DIFF
--- a/create-cloud-resources.yml
+++ b/create-cloud-resources.yml
@@ -51,6 +51,7 @@
           security_groups:
             - sg-common
             - sg-http-https
+            - sg-logstash
           key_name: "{{ deploy_ssh_key_name }}"
         - name: logs
           floating_ip_address: 169.44.171.84

--- a/roles/cloud-bootstrap/defaults/main.yml
+++ b/roles/cloud-bootstrap/defaults/main.yml
@@ -85,6 +85,10 @@ common_security_group_rules:
         port: 80
       - remote_cidr: 0.0.0.0/0
         port: 443
+  - name: sg-logstash
+    rules:
+      - remote_group: sg-control-plane
+        port: 5044
 
 
 environment_security_group_rules:
@@ -112,6 +116,7 @@ common_servers:
     security_groups:
       - sg-common
       - sg-http-https
+      - sg-logstash
     key_name: "{{ deploy_ssh_key_name }}"
   - name: logs
     floating_ip_network: external


### PR DESCRIPTION
Logstash opens port 5044 for incoming logs sent by filebeat on
nodepool and zuul. This port needs to be open in the security groups,
so add a new security group and add it to the elk host.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>