### PR TITLE
Set nodepool v3 branch back to upstream

### DIFF
--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -1,8 +1,8 @@
 nodepool_zuul_v3: true
 zuul_zuul_v3: True
 
-nodepool_git_repo_url: https://github.com/jamielennox/nodepool
-nodepool_git_version: nodepool-split
+nodepool_git_repo_url: https://github.com/openstack-infra/nodepool
+nodepool_git_version: feature/zuulv3
 
 zuul_git_repo_url: https://github.com/openstack-infra/zuul
 zuul_git_branch: feature/zuulv3


### PR DESCRIPTION
This patch was merged, used upstream nodepool again.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>