### PR TITLE
Nodepool-v3 network should create nodes with open access

### DIFF
--- a/roles/cloud-bootstrap/defaults/main.yml
+++ b/roles/cloud-bootstrap/defaults/main.yml
@@ -46,6 +46,7 @@ prod_quota:
 prod_nodepool_projects:
     - name: nodepool
       user: nodepool
+      controlplane_network_cidr: 192.168.10.0/24
       quota:
         cores: -1
         fixed_ips: -1
@@ -55,6 +56,7 @@ prod_nodepool_projects:
         ram: -1
     - name: nodepool_v3
       user: nodepool_v3
+      controlplane_network_cidr: 192.168.30.0/24
       quota:
         cores: -1
         fixed_ips: -1
@@ -67,7 +69,6 @@ common_network_name: "ci-common"
 common_network_cidr: 192.168.5.0/24
 controlplane_network_name: "control-plane"
 nodepool_network_name: "nodepool"
-controlplane_network_cidr: 192.168.10.0/24
 router_name: "bonnyci-router"
 nodepool_network_cidr: 10.0.0.0/8
 external_network_name: external

--- a/roles/cloud-bootstrap/tasks/network.yml
+++ b/roles/cloud-bootstrap/tasks/network.yml
@@ -60,7 +60,8 @@
     protocol: "tcp"
     port_range_min: "1"
     port_range_max: "65535"
-    remote_ip_prefix: "{{ controlplane_network_cidr }}"
+    remote_ip_prefix: "{{ item.controlplane_network_cidr }}"
     auth:
-      project_name: "{{ prod_nodepool_project }}"
+      project_name: "{{ item.name }}"
   when: "{{ split_tenants | bool }}"
+  with_items: "{{ prod_nodepool_projects }}"


### PR DESCRIPTION
Nodepool will try to ssh to the newly created nodes to verify that they
are up. To do this they need to be in a security group that allows it.
The way this is handled in v2 is that the default sg just allows access
to all ports from the control plane network. This is probably
unnecessary and should be just SSH, but replicate it for now.

This has not actually been tested because I don't really have the
ability, but it reflects a change I had to make on the cloud.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>