### PR TITLE
Rename nodepoold to nodepool-launcher in v3

### DIFF
--- a/roles/nodepool/handlers/main.yml
+++ b/roles/nodepool/handlers/main.yml
@@ -20,7 +20,7 @@
     state: restarted
   with_items:
     - nodepool-builder
-    - nodepoold
+    - nodepool-launcher
 
 - name: Restart nodepool builder
   service:

--- a/roles/nodepool/tasks/nodepool_v3.yml
+++ b/roles/nodepool/tasks/nodepool_v3.yml
@@ -8,7 +8,7 @@
     mode: 0640
   with_items:
     - nodepool-builder
-    - nodepoold
+    - nodepool-launcher
 
 - name: Install systemd unit files
   template:
@@ -19,7 +19,7 @@
     mode: 0644
   with_items:
     - nodepool-builder
-    - nodepoold
+    - nodepool-launcher
   notify:
     - Reload systemd units
     - Restart nodepool
@@ -33,4 +33,4 @@
     service: "{{ item }}"
   with_items:
     - nodepool-builder
-    - nodepoold
+    - nodepool-launcher

--- a/roles/nodepool/templates/etc/systemd/system/nodepool-launcher.service
+++ b/roles/nodepool/templates/etc/systemd/system/nodepool-launcher.service
@@ -7,7 +7,11 @@ Type=simple
 User=nodepool
 Group=nodepool
 EnvironmentFile=-/etc/default/nodepool
+{% if nodepool_zuul_v3 %}
+ExecStart={{ nodepool_venv_path }}/bin/nodepool-launcher -d -l /etc/nodepool/nodepool-launcher_logging.conf
+{% else %}
 ExecStart={{ nodepool_venv_path }}/bin/nodepoold -d --no-deletes --no-webapp -l /etc/nodepool/nodepool-launcher_logging.conf
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/nodepool/templates/etc/systemd/system/nodepoold.service
+++ b/roles/nodepool/templates/etc/systemd/system/nodepoold.service
@@ -7,11 +7,7 @@ Type=simple
 User=nodepool
 Group=nodepool
 EnvironmentFile=-/etc/default/nodepool
-{% if nodepool_zuul_v3 %}
-ExecStart={{ nodepool_venv_path }}/bin/nodepoold -d -l /etc/nodepool/nodepoold_logging.conf
-{% else %}
 ExecStart={{ nodepool_venv_path }}/bin/nodepoold -d --no-deletes --no-launches -l /etc/nodepool/nodepoold_logging.conf
-{% endif %}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Commit fbe932e1 renames nodepoold to nodepool-launcher. Our v3 deploy
must therefore do the same thing.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>