### PR TITLE
Add a custom bash prompt for nodepool and zuul nodes

### DIFF
--- a/inventory/group_vars/opentech-sjc
+++ b/inventory/group_vars/opentech-sjc
@@ -1,3 +1,5 @@
+environment_name: opentech-sjc
+
 bastion_clouds:
   - opentech-sjc
 

--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -1,3 +1,5 @@
+environment_name: opentech-sjc-v3
+
 nodepool_zuul_v3: true
 zuul_zuul_v3: True
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -15,3 +15,9 @@
     regexp: '^127\.0\.0\.1'
     line: '127.0.0.1 {{ ansible_hostname }} localhost'
   tags: ['not-on-docker']
+
+- name: Set custom bash prompt for per-environment nodes
+  template:
+    dest: /etc/profile.d/bash_prompt.sh
+    src: etc/profile.d/bash_prompt.sh
+  when: environment_name is defined

--- a/roles/common/templates/etc/profile.d/bash_prompt.sh
+++ b/roles/common/templates/etc/profile.d/bash_prompt.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# shellcheck disable=2154
+PROMPT_COMMAND="export PS1='${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h[{{ environment_name }}]\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '"


### PR DESCRIPTION
This adds a custom bash prompt to nodepool and zuul nodes that specifies
the environment each is running in.  This is reduces confusion with
multiple terminals open across the different environments.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>