### PR TITLE
Fix apache server aliases

### DIFF
--- a/inventory/group_vars/log
+++ b/inventory/group_vars/log
@@ -9,7 +9,7 @@ bonnyci_logs_apache_mods_install:
 bonnyci_logs_apache_vhosts:
   - name: logs
     server_name: "{{ bonnyci_logs_apache_server_name | default('logs') }}"
-    aliases: "{{ bonnyci_logs_apache_server_aliases | default('kibana') }}"
+    aliases: "{{ bonnyci_logs_apache_server_aliases | default([]) }}"
     document_root: "{{ bonnyci_logs_root_dir }}/logs"
     document_root_allow_override: None
     document_root_options: "+Indexes +FollowSymLinks"

--- a/inventory/group_vars/monitoring
+++ b/inventory/group_vars/monitoring
@@ -4,8 +4,8 @@ bonnyci_kibana_apache_mods_enabled:
 
 bonnyci_kibana_apache_vhosts:
   - name: kibana
-    server_name: "{{ bonnyci_logs_kibana_server_name | default('elk') }}"
-    aliases: "{{ bonnyci_logs_kibana_server_aliases | default('kibana') }}"
+    server_name: "{{ bonnyci_kibana_apache_server_name | default('elk') }}"
+    aliases: "{{ bonnyci_kibana_apache_server_aliases | default([]) }}"
     vhost_extra: |
       ProxyPreserveHost On
       ProxyRequests On


### PR DESCRIPTION
Change the default aliases to an empty list, and correct the variable names
used by the kibana vhost parameters.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>