### PR TITLE
Drop elk and logs hosts from opentech-sjc

### DIFF
--- a/inventory/opentech-sjc
+++ b/inventory/opentech-sjc
@@ -13,22 +13,13 @@ zuul.internal.opentechsjc.bonnyci.org
 [zookeeper]
 nodepool.internal.opentechsjc.bonnyci.org
 
-[log]
-logs.internal.opentechsjc.bonnyci.org
-
-[monitoring]
-elk.internal.opentechsjc.bonnyci.org
 
 [production]
 nodepool.internal.opentechsjc.bonnyci.org
 zuul.internal.opentechsjc.bonnyci.org
 merger01.internal.opentechsjc.bonnyci.org
-logs.internal.opentechsjc.bonnyci.org
-elk.internal.opentechsjc.bonnyci.org
 
 [opentech-sjc]
 nodepool.internal.opentechsjc.bonnyci.org
 zuul.internal.opentechsjc.bonnyci.org
 merger01.internal.opentechsjc.bonnyci.org
-logs.internal.opentechsjc.bonnyci.org
-elk.internal.opentechsjc.bonnyci.org


### PR DESCRIPTION
These hosts now live in the opentech-sjc-common inventory.  They
can be removed from opentech-sjc to avoid deploying to them twice.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>