### PR TITLE
Update nodepool v3 provider config

### DIFF
--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -30,24 +30,21 @@ nodepool_mysql_host: zuul.internal.v3.opentechsjc.bonnyci.org
 nodepool_providers:
   - name: cicloud-v3
     cloud: opentech-sjc-v3
-    max-servers: 2
-    networks:
-      - name: 'nodepool-v3'
-        public: True
-    images:
+    diskimages:
       - name: ubuntu-xenial
-        min-ram: 1026
-        diskimage: ubuntu-xenial
-        private-key: /var/lib/nodepool/.ssh/id_rsa
-        user-home: /home/bonnyci
-        username: bonnyci
+    pools:
+      - name: main
+        max-servers: 2
+        networks:
+          - nodepool-v3
+        labels:
+          - name: ubuntu-xenial
+            min-ram: 1026
+            diskimage: ubuntu-xenial
 
 nodepool_labels:
   - name: ubuntu-xenial
-    image: ubuntu-xenial
     min-ready: 1
-    providers:
-      - name: cicloud-v3
 
 nodepool_zmq_publishers:
   - tcp://zuul.internal.v3.opentechsjc.bonnyci.org:8888


### PR DESCRIPTION
This updates the v3 nodepool configuration format to match
whats documented.  Specifically, it adds the 'pools' section to the
providers and removes a bunch of stuff that is no longer needed.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>