### PR TITLE
Disable apache forward proxying

### DIFF
--- a/inventory/group_vars/monitoring
+++ b/inventory/group_vars/monitoring
@@ -8,7 +8,6 @@ bonnyci_kibana_apache_vhosts:
     aliases: "{{ bonnyci_kibana_apache_server_aliases | default([]) }}"
     vhost_extra: |
       ProxyPreserveHost On
-      ProxyRequests On
       ProxyPass / http://127.0.0.1:5601/
       ProxyPassReverse / http://127.0.0.1:5601/
 


### PR DESCRIPTION
This should only be a reverse proxy, we do not want forward
proxying enabled.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>