### PR TITLE
Add a default deny apache vhost to elk

### DIFF
--- a/inventory/group_vars/monitoring
+++ b/inventory/group_vars/monitoring
@@ -2,7 +2,16 @@ bonnyci_kibana_apache_mods_enabled:
   - proxy.load
   - proxy_http.load
 
+
 bonnyci_kibana_apache_vhosts:
+  - name: default_deny
+    server_name: default.only
+    vhost_extra: |
+      <Location />
+        Order allow,deny
+        Deny from all
+      </Location>
+
   - name: kibana
     server_name: "{{ bonnyci_kibana_apache_server_name | default('elk') }}"
     aliases: "{{ bonnyci_kibana_apache_server_aliases | default([]) }}"

--- a/inventory/group_vars/opentech-sjc
+++ b/inventory/group_vars/opentech-sjc
@@ -3,12 +3,6 @@ environment_name: opentech-sjc
 bastion_clouds:
   - opentech-sjc
 
-bonnyci_kibana_apache_server_name: elk.opentechsjc.bonnyci.org
-bonnyci_kibana_apache_server_aliases:
-  - elk.bonnyci.org
-bonnyci_logs_apache_server_name: logs.opentechsjc.bonnyci.org
-bonnyci_logs_apache_server_aliases:
-  - logs.bonnyci.org
 bonnyci_logs_scp_host: logs.internal.opentechsjc.bonnyci.org
 bonnyci_zuul_webapp_apache_server_name: zuul.opentechsjc.bonnyci.org
 bonnyci_zuul_merger_apache_server_name: merger01.internal.opentechsjc.bonnyci.org

--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -9,12 +9,6 @@ nodepool_git_version: feature/zuulv3
 zuul_git_repo_url: https://github.com/openstack-infra/zuul
 zuul_git_branch: feature/zuulv3
 
-bonnyci_kibana_apache_server_name: elk.opentechsjc.bonnyci.org
-bonnyci_kibana_apache_server_aliases:
-  - elk.bonnyci.org
-bonnyci_logs_apache_server_name: logs.opentechsjc.bonnyci.org
-bonnyci_logs_apache_server_aliases:
-  - logs.bonnyci.org
 bonnyci_logs_scp_host: logs.internal.opentechsjc.bonnyci.org
 bonnyci_zuul_webapp_apache_server_name: zuul.v3.opentechsjc.bonnyci.org
 bonnyci_zuul_merger_apache_server_name: merger01.internal.v3.opentechsjc.bonnyci.org


### PR DESCRIPTION
A previous commit that was meant to setup kibana reverse proxying
mistakenly opened the host up as a public forward proxy, and was
picked up as a backend for a public proxying service. Forward
proxying was disabled, but we're still getting tons of incoming
proxy requests.  This sets up a default vhost to deny these and
only accept requests explicitly bound for configured vhosts.  This
will hopefully result in the address being pulled from the proxy
service's database.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>