### PR TITLE
Put a requests logger on zuul

### DIFF
--- a/roles/zuul/templates/etc/zuul/logging.conf
+++ b/roles/zuul/templates/etc/zuul/logging.conf
@@ -1,9 +1,9 @@
 # {{ ansible_managed }}
 [loggers]
-keys=root,zuul,gerrit,gear
+keys=root,zuul,gerrit,gear,requests
 
 [handlers]
-keys=debug,normal{% if zuul_use_datadog_logging %},datadog{% endif %}
+keys=debug,normal{% if zuul_use_datadog_logging %},datadog{% endif %},requests
 
 [formatters]
 keys=simple
@@ -27,6 +27,11 @@ level=DEBUG
 handlers=debug,normal
 qualname=gear
 
+[logger_requests]
+level=DEBUG
+handlers=requests
+qualname=requests
+
 [handler_debug]
 level=DEBUG
 class=logging.handlers.WatchedFileHandler
@@ -46,6 +51,12 @@ class=datadog_logging.DatadogLogStatsdHandler
 formatter=simple
 args=()
 {% endif %}
+
+[handler_requests]
+level=DEBUG
+class=logging.handlers.WatchedFileHandler
+formatter=simple
+args=('/var/log/zuul/{{ item }}-requests.log',)
 
 [formatter_simple]
 format=%(asctime)s %(levelname)s %(name)s: %(message)s


### PR DESCRIPTION
We want to log the requests being made to github to validate that the
caching is working correctly and seeing the quotas.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>