### PR TITLE
Add missing opentech-sjc-common group_vars

### DIFF
--- a/inventory/group_vars/opentech-sjc-common
+++ b/inventory/group_vars/opentech-sjc-common
@@ -1,0 +1,6 @@
+bonnyci_kibana_apache_server_name: elk.opentechsjc.bonnyci.org
+bonnyci_kibana_apache_server_aliases:
+  - elk.bonnyci.org
+bonnyci_logs_apache_server_name: logs.opentechsjc.bonnyci.org
+bonnyci_logs_apache_server_aliases:
+  - logs.bonnyci.org


### PR DESCRIPTION
This is required to set elk apache vhosts correctly but was mistakenly
left out of the last commit.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>