### PR TITLE
Manage ssh known hosts for zuul

### DIFF
--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -73,3 +73,7 @@ zuul_tenants:
 dns_subdomain: internal.v3.opentechsjc.bonnyci.org
 zuul_zookeeper_hosts:
   - nodepool.internal.v3.opentechsjc.bonnyci.org:2181
+
+zuul_ssh_known_hosts:
+  - host: "[review.gerrithub.io]:29418"
+    key: "[review.gerrithub.io]:29418 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAtcxtihbxvcTxe/wP2CfaVP7DeCZkEvuW/LFWWfUChCknnlAbem64BlMdsEAvgm2VzIQNWxqI8iyJxoOasR9o42DDsH68YIM+5/o2rHw1emhiSQ3RNmdSGBDqNqg15WHqyR0QVl+lX423MWgXAKmGPuZo9t4ZJ+DdHfO5BVewPPOiEtHUs/IaYDLl8EEFwVZj6wkEUehpq/gFD3WmasPDb4CTZqPH3Z+K5QC8j297laHKPvqa+tE/UGjpWMFXMZTmPd7zNVUoLsSbkqkpE3TUWzLS4OMTtnJdqKlAIRV0pRVYxLp4WXQfg9+NKOqR49pgBGFCIUxtVWLdh23JgVmpnQ=="

--- a/roles/zuul/tasks/main.yml
+++ b/roles/zuul/tasks/main.yml
@@ -55,6 +55,21 @@
     group: zuul
     mode: 0644
 
+- name: Install any ssh known host keys
+  known_hosts:
+    path: /var/lib/zuul/.ssh/known_hosts
+    key: "{{ item.key }}"
+    host: "{{ item.host }}"
+  with_items: "{{ zuul_ssh_known_hosts }}"
+  when: zuul_ssh_known_hosts is defined
+
+- name: Ensure zuul ssh known_hosts ownership
+  file:
+    path: /var/lib/zuul/.ssh/known_hosts
+    owner: zuul
+    group: zuul
+  when: zuul_ssh_known_hosts is defined
+
 - name: Install zuul integration key
   copy:
     dest: /etc/zuul/integration.key


### PR DESCRIPTION
This is mainly going to be used for managing ssh host keys
for the gerrit connection while we are testing V3.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>