### PR TITLE
Add ssh-host-keys role

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -85,6 +85,9 @@
       tags:
         - monitoring
 
+    - role: ssh-host-keys
+      ssh_host_keys_hostnames: log
+
     - role: apache
       apache_mods_enabled: "{{ bonnyci_zuul_webapp_apache_mods_enabled }}"
       apache_vhosts: "{{ bonnyci_zuul_webapp_apache_vhosts }}"

--- a/roles/ssh-host-keys/defaults/main.yml
+++ b/roles/ssh-host-keys/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+ssh_host_keys_path: /etc/ssh/ssh_known_hosts

--- a/roles/ssh-host-keys/tasks/key.yml
+++ b/roles/ssh-host-keys/tasks/key.yml
@@ -1,0 +1,16 @@
+- name: Install ssh-rsa key
+  known_hosts:
+    name: "{{ item }}-rsa"
+    key: "{{ item }}-rsa,{{ item }},{{ hostvars[item].ansible_default_ipv4.address }} ssh-rsa {{ hostvars[item].ansible_ssh_host_key_rsa_public }}"
+    path: "{{ ssh_host_keys_path }}"
+    state: present
+  when: '"ansible_ssh_host_key_rsa_public" in hostvars[item]'
+
+# dsa key validation fails for some reason - we probably don't want it anyway
+# - name: Install ssh-dsa key
+#   known_hosts:
+#     name: "{{ item }}-dsa"
+#     key: "{{ item }}-dsa,{{ item }},{{ hostvars[item].ansible_default_ipv4.address }} ssh-dsa {{ hostvars[item].ansible_ssh_host_key_dsa_public }}"
+#     path: "{{ ssh_host_keys_path }}"
+#     state: present
+#   when: '"ansible_ssh_host_key_dsa_public" in hostvars[item]'

--- a/roles/ssh-host-keys/tasks/main.yml
+++ b/roles/ssh-host-keys/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- include: key.yml
+  when: item in hostvars
+  with_inventory_hostnames: "{{ ssh_host_keys_hostnames | mandatory }}"
+
+# Just in case nothing happened above we can't user/group an empty file
+- name: Test host key file exists
+  stat:
+    path: "{{ ssh_host_keys_path }}"
+  register: ssh_host_key_stat
+
+- name: Ensure host key file
+  file:
+    name: "{{ ssh_host_keys_path }}"
+    owner: "{{ ssh_host_keys_user | default(omit) }}"
+    group: "{{ ssh_host_keys_group | default(omit) }}"
+    state: file
+  when: ssh_host_key_stat.stat.exists


### PR DESCRIPTION
We need to have the SSH host keys for logs on the zuul servers so that
they can upload logs to them. The most generic way i can think of is to
make a role that fetches and saves the host keys for all the specified
groups.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>