### PR TITLE
Add add logs host key to zuul v3

### DIFF
--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -71,3 +71,5 @@ zuul_zookeeper_hosts:
 zuul_ssh_known_hosts:
   - host: "[review.gerrithub.io]:29418"
     key: "[review.gerrithub.io]:29418 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAtcxtihbxvcTxe/wP2CfaVP7DeCZkEvuW/LFWWfUChCknnlAbem64BlMdsEAvgm2VzIQNWxqI8iyJxoOasR9o42DDsH68YIM+5/o2rHw1emhiSQ3RNmdSGBDqNqg15WHqyR0QVl+lX423MWgXAKmGPuZo9t4ZJ+DdHfO5BVewPPOiEtHUs/IaYDLl8EEFwVZj6wkEUehpq/gFD3WmasPDb4CTZqPH3Z+K5QC8j297laHKPvqa+tE/UGjpWMFXMZTmPd7zNVUoLsSbkqkpE3TUWzLS4OMTtnJdqKlAIRV0pRVYxLp4WXQfg9+NKOqR49pgBGFCIUxtVWLdh23JgVmpnQ=="
+  - host: "logs.internal.opentechsjc.bonnyci.org"
+    key: "logs.internal.opentechsjc.bonnyci.org ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDM7tV7He/uofAwgYpkpKLuc+AN4z+HM9yUrs0V0ELhhCYZrTqeA940U46KItEgJK3/7xJQTlhh//erOmUVumOx8Grhpuvzru5wypOlXuCemYtbBrAIRrzmY0+oYgG7OLXqKMApuLr5UKGMjC4+dw4mD0VnmUBScUHypzrDgFEN8TMAaXNu1+ciju20yF7uGeQEZUiP5GKaIIj0ko+FAN6fK1a5JURX8xNrVOjqKxfl1ZLODfuT5K54pUDWf96+nho98k22PG21zLHK86e0aYraE4H5OiHK3993NeQc5Xos+j+T9ZnAcPdQxZmGh2HobBhKRejdY+IdYy+KSxSBamMd"


### PR DESCRIPTION
We need to ensure this is in zuul v3's known hosts for log publishing.

This is a temporary solution until we come up with a more generic way of managing ssh host keys, see https://github.com/BonnyCI/hoist/pull/313

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>