### PR TITLE
zuulv3: Update project-config repo name

### DIFF
--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -60,7 +60,7 @@ zuul_tenants:
     source:
       gerrithub:
         config-repos:
-          - bonnyci/project-config
+          - bonnyci/project-config-v3
         project-repos:
           - bonnyci/sandbox-v3
 


### PR DESCRIPTION
There was an issue with gerrithub importing this repo from github and
the original is in some weird state that cant be accessed or deleted, so
I needed to rename it and re-import.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>