### PR TITLE
Add force option to ansible-runner

### DIFF
--- a/roles/ansible-runner/files/usr/local/bin/ansible-runner
+++ b/roles/ansible-runner/files/usr/local/bin/ansible-runner
@@ -17,9 +17,14 @@ if ! ([ -n "$ANSIBLE_PLAYBOOK" ] && [ -n "$ANSIBLE_INVENTORY" ]); then
   exit 1
 fi
 
-if [ -f /etc/disable-ansible-runner-"$env" ]; then
-    echo "Environment $env is disabled by file."
-    exit 1
+if [[ "$*" == *"--force"* && "$*" != *"--force-"* ]]; then
+    echo "--force detected, ignoring /etc/disable-ansible-runner-$env..."
+else
+    if [ -f /etc/disable-ansible-runner-"$env" ]; then
+        echo "Environment $env is disabled by file."
+        echo "If you want to run $0 anyway, use \"--force\"."
+        exit 1
+    fi
 fi
 
 if [[ -z "${ANSIBLE_SERIALIZED:-}" ]] ; then


### PR DESCRIPTION
Previously, if ansible-runner needed to be run by hand but was disabled
to stop the cronjob from running every 15 minutes, one had to reenable
ansible-runner, thus permitting the cronjob to run at it's next
interval. This opened unwanted possibilities like the cronjob running
in the background when a manual run was wanted, or forgetting to disable
the job again.

Now there is a force option (`--force`) for ansible-runner.
Unfortunately, the standard short form (`-f`) will not be available to
us, because we need to be able to pass additional options to ansible,
which uses `-f` to specify a number of forks.

Related-Issue: BonnyCI/projman#195
Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>