### PR TITLE
Specify nodepool_diskimages for opentech-sjc-v3

### DIFF
--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -42,6 +42,28 @@ nodepool_labels:
   - name: ubuntu-xenial
     min-ready: 1
 
+nodepool_diskimages:
+  - name: ubuntu-xenial
+    elements:
+      - ubuntu-minimal
+      - vm
+      - simple-init
+      - growroot
+      - openssh-server
+      - devuser
+      - haveged
+      - pip-and-virtualenv
+      - nodepool
+      - bonnyci-nodepool
+    release: xenial
+    env-vars:
+      DIB_DEV_USER_USERNAME: zuul
+      DIB_DEV_USER_AUTHORIZED_KEYS: /etc/nodepool/slave-authorized-keys
+      DIB_DEV_USER_PWDLESS_SUDO: 'Yes'
+      DIB_DEV_USER_SHELL: /bin/bash
+      DIB_NODEPOOL_SCRIPT_DIR: /etc/nodepool/scripts
+      DIB_PYTHON_VERSION: '2'
+
 nodepool_zmq_publishers:
   - tcp://zuul.internal.v3.opentechsjc.bonnyci.org:8888
 


### PR DESCRIPTION
Until https://review.openstack.org/#/c/453983/ and its dependent land, we can
override the diskimages for the v3 environment and specify the default 'zuul'
username instead of bonnyci.  This can be reverted once the issue is resolved
upstream.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>