### PR TITLE
Fix handling of force option in ansible-runner

### DIFF
--- a/roles/ansible-runner/files/usr/local/bin/ansible-runner
+++ b/roles/ansible-runner/files/usr/local/bin/ansible-runner
@@ -2,7 +2,7 @@
 # Runs system wide ansible configured in /etc
 
 env=$1
-
+shift
 if [ -f /etc/default/"$env" ]; then
   . /etc/default/"$env"
 fi
@@ -11,28 +11,31 @@ envs_root=${ANSIBLE_RUNNER_ENV_ROOT:-/opt/source}
 ansible_venv=${ANSIBLE_RUNNER_VENV:-/opt/ansible}
 log_dir=${ANSIBLE_RUNNER_LOG_DIR:-/var/www/html/cron-logs/$env/}
 ssh_user=${ANSIBLE_SSH_USER:-""}
+force_runner=false
+ansible_options=""
 
 if ! ([ -n "$ANSIBLE_PLAYBOOK" ] && [ -n "$ANSIBLE_INVENTORY" ]); then
   echo "Missing all required environment variables: ANSIBLE_PLAYBOOK, ANSIBLE_INVENTORY"
   exit 1
 fi
 
-if [[ "$*" == *"--force"* && "$*" != *"--force-"* ]]; then
-    echo "--force detected, ignoring /etc/disable-ansible-runner-$env..."
+for argument in "$@"; do
+    if [[ "$argument" == "--force-runner" ]]; then
+        force_runner=true
+    else
+        ansible_options="$ansible_options $argument"
+    fi
+done
+
+if $force_runner; then
+    echo "--force-runner detected, ignoring /etc/disable-ansible-runner-$env..."
 else
     if [ -f /etc/disable-ansible-runner-"$env" ]; then
         echo "Environment $env is disabled by file."
-        echo "If you want to run $0 anyway, use \"--force\"."
+        echo "If you want to run $0 anyway, use \"--force-runner\"."
         exit 1
     fi
 fi
-
-if [[ -z "${ANSIBLE_SERIALIZED:-}" ]] ; then
-    export ANSIBLE_SERIALIZED=1
-    exec run-one "$0" "$@"
-fi
-
-shift
 
 set +u
 . "$ansible_venv"/bin/activate
@@ -54,11 +57,10 @@ if [ -f requirements.txt ]; then
   sudo "$ansible_venv"/bin/pip install -U -r requirements.txt 2>&1 | tee -a "$logfile"
 fi
 
-args="$*"
 if [ -n "$ssh_user" ]; then
-    args="$args -e ansible_ssh_user=$ssh_user"
+    ansible_options="$ansible_options -e ansible_ssh_user=$ssh_user"
 fi
-"$ansible_venv"/bin/ansible-playbook -vv -i "$ANSIBLE_INVENTORY" $args "$ANSIBLE_PLAYBOOK" 2>&1 | tee -a "$logfile"
+"$ansible_venv"/bin/ansible-playbook -vv -i "$ANSIBLE_INVENTORY" $ansible_options "$ANSIBLE_PLAYBOOK" 2>&1 | tee -a "$logfile"
 date 2>&1 | tee -a "$logfile"
 
 # Remove > 10 days old

--- a/roles/ansible-runner/tasks/main.yml
+++ b/roles/ansible-runner/tasks/main.yml
@@ -14,7 +14,6 @@
   with_items:
     - python-dev
     - libssl-dev
-    - run-one
     - git
     - cron
 

--- a/tests/test-ansible-runner.sh
+++ b/tests/test-ansible-runner.sh
@@ -19,8 +19,6 @@ mkdir "$test_log_dir"
 
 virtualenv "$test_venv"
 
-sudo apt-get -y install run-one
-
 function run_runner() {
   echo "Running ansible-runner, expecting to run playbook:"
   cat "$repo_playbook"


### PR DESCRIPTION
Previously, the --force option was being passed to ansible after being
used to force the ansible-runner script because ansible uses the
deprecated optparse, which allows for abbreviated options. As a result
`--force` was being interpreted by ansible-playbook as
`--force-handlers`.

Now, ansible-runner uses the more obvious `--force-runner` (per
@gandelman-a's request), which switches on `force_runner`. All other
arguments are moved to the `ansible_options` string, which is in turn
passed to `ansible-playbook`.

With these changes made, run-one breaks the script. However, our
deployments are currently unlikely to be impacted by us not using
run-one. As such, it has been removed.

Related-Issue: BonnyCI/projman#211
Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>