### PR TITLE
Set reporting URL on zuul v3 deploy

### DIFF
--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -90,6 +90,8 @@ dns_subdomain: internal.v3.opentechsjc.bonnyci.org
 zuul_zookeeper_hosts:
   - nodepool.internal.v3.opentechsjc.bonnyci.org:2181
 
+zuul_url_pattern: "https://logs.bonnyci.org/{build.parameters[ZUUL_PIPELINE]}/{build.parameters[ZUUL_PROJECT]}/{build.parameters[ZUUL_CHANGE]}/{build.parameters[ZUUL_UUID]}"
+
 zuul_ssh_known_hosts:
   - host: "[review.gerrithub.io]:29418"
     key: "[review.gerrithub.io]:29418 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAtcxtihbxvcTxe/wP2CfaVP7DeCZkEvuW/LFWWfUChCknnlAbem64BlMdsEAvgm2VzIQNWxqI8iyJxoOasR9o42DDsH68YIM+5/o2rHw1emhiSQ3RNmdSGBDqNqg15WHqyR0QVl+lX423MWgXAKmGPuZo9t4ZJ+DdHfO5BVewPPOiEtHUs/IaYDLl8EEFwVZj6wkEUehpq/gFD3WmasPDb4CTZqPH3Z+K5QC8j297laHKPvqa+tE/UGjpWMFXMZTmPd7zNVUoLsSbkqkpE3TUWzLS4OMTtnJdqKlAIRV0pRVYxLp4WXQfg9+NKOqR49pgBGFCIUxtVWLdh23JgVmpnQ=="


### PR DESCRIPTION
Zuul v3 doesn't have the python common functions file which is currently
setting our logs URL to something reasonable. This means we have to
encode it into the config file instead - which is probably better.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>