### PR TITLE
Put an SSL certificate on logs.bonnyci.org

### DIFF
--- a/inventory/host_vars/logs.internal.opentechsjc.bonnyci.org
+++ b/inventory/host_vars/logs.internal.opentechsjc.bonnyci.org
@@ -1,0 +1,2 @@
+---
+letsencrypt_csr_cn: logs.bonnyci.org


### PR DESCRIPTION
We should be accessing logs over SSL. Adding a letsencrypt csr cn should
be all that is required here - but it's fairly difficult to test so lets
run it and see.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>