### PR TITLE
Use correct path to os_loganalyze config

### DIFF
--- a/roles/os-loganalyze/templates/etc/os_loganalyze/wsgi.conf
+++ b/roles/os-loganalyze/templates/etc/os_loganalyze/wsgi.conf
@@ -1,5 +1,5 @@
 [general]
 filter = SevFilter
 view = HTMLView
-file_conditions = /etc/os-loganalyze/file_conditions.yaml
+file_conditions = /etc/os_loganalyze/file_conditions.yaml
 generate_folder_index = false


### PR DESCRIPTION
The loganalyze config file is pointing to the wrong file_conditions path
which i think is meaning that some things aren't rendered correctly.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>