### PR TITLE
Move the existing bonnyci log config to ssl

### DIFF
--- a/inventory/group_vars/log
+++ b/inventory/group_vars/log
@@ -14,6 +14,11 @@ bonnyci_logs_apache_vhosts:
     document_root_allow_override: None
     document_root_options: "+Indexes +FollowSymLinks"
 
+    ssl: "{{ bonnyci_logs_ssl | default(False) }}"
+    certificate_file: "{{ letsencrypt_cert_path | default('') }}"
+    certificate_key_file: "{{ letsencrypt_key_path | default('') }}"
+    certificate_chain_file: "{{ letsencrypt_chain_path | default('') }}"
+
     vhost_extra: |
       <Directory /etc/os_loganalyze/wsgi>
         Require all granted

--- a/inventory/host_vars/logs.internal.opentechsjc.bonnyci.org
+++ b/inventory/host_vars/logs.internal.opentechsjc.bonnyci.org
@@ -1,2 +1,3 @@
 ---
 letsencrypt_csr_cn: logs.bonnyci.org
+bonnyci_logs_ssl: yes


### PR DESCRIPTION
The letsencrypt vhost is clashing with the existing vhost. Move the logs
vhost over to port 443 as we are going to want it there anyway.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>