### PR TITLE
Manually set letsencrypt paths in log's group_vars

### DIFF
--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -6,6 +6,8 @@ bonnyci_logs_scp_user: zuul
 filebeat_output_logstash_enabled: true
 
 letsencrypt_account_key_content: "{{ secrets.letsencrypt.account_key }}"
+letsencrypt_cert_path: /etc/apache2/cert/ansible.crt
+letsencrypt_chain_path: /etc/letsencrypt/chain.pem
 letsencrypt_csr_dn:
   C: AU
   ST: NSW
@@ -13,6 +15,7 @@ letsencrypt_csr_dn:
   O: BonnyCI
 letsencrypt_configure_redirect: yes
 letsencrypt_email: jamielennox@gmail.com
+letsencrypt_key_path: /etc/apache2/cert/ansible.key
 
 zuul_gearman_server_listen_address: 0.0.0.0
 zuul_gearman_server_start: true

--- a/inventory/group_vars/zuul
+++ b/inventory/group_vars/zuul
@@ -3,10 +3,6 @@ bonnyci_zuul_webapp_apache_mods_enabled:
   - proxy_http.load
   - rewrite.load
 
-letsencrypt_key_path: /etc/apache2/cert/ansible.key
-letsencrypt_cert_path: /etc/apache2/cert/ansible.crt
-letsencrypt_chain_path: /etc/letsencrypt/chain.pem
-
 bonnyci_zuul_webapp_apache_vhosts:
   - name: status
     delete: true


### PR DESCRIPTION
These values are supposed to be inheritted from the letsencrypt role
defaults however the variables do not persist for this long. Really we
should find a better more common way of defining them then but to solve
an immediate problem define them the same way that zuul does.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>