### PR TITLE
Add bonnyci.org link to merge-failure-message

### DIFF
--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -37,3 +37,5 @@ zuul_zuul_v3: False
 
 zuul_zookeeper_hosts:
   - "127.0.0.1:2181"
+
+zuul_merge_failure_message: "Merge Failed! Help can be found at https://bonnyci.org/lore/end_users/use/#handling-merge-failures"

--- a/roles/zuul/templates/etc/zuul/config/layout.yaml
+++ b/roles/zuul/templates/etc/zuul/config/layout.yaml
@@ -7,6 +7,7 @@ pipelines:
   - name: check_github
     manager: IndependentPipelineManager
     source: github
+    merge-failure-message: "{{ zuul_merge_failure_message }}"
     trigger:
       github:
         - event:
@@ -33,6 +34,7 @@ pipelines:
     manager: DependentPipelineManager
     precedence: high
     source: github
+    merge-failure-message: "{{ zuul_merge_failure_message }}"
     trigger:
       github:
         - event: status


### PR DESCRIPTION
We should direct users to a place with some documentation on where to
get help on resolving merge failures.

Implements: BonnyCI/projman#199
Depends-On: BonnyCI/bonnyci.org#57

Signed-off-by: Cullen Taylor <cullentaylor@outlook.com>