### PR TITLE
Fix permission changes during bastion.yml run

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,7 +50,7 @@ Vagrant.configure(2) do |config|
       if test -f /etc/secrets.yml ; then
         rm /etc/secrets.yml
       fi
-      ln -s /vagrant/secrets.yml /etc/secrets.yml
+      cp /vagrant/secrets.yml /etc/secrets.yml
 
       # disable cron runs, run ansible manually while testing
       touch /etc/disable-ansible-runner-cideploy

--- a/roles/ansible-runner/tasks/secret-file.yml
+++ b/roles/ansible-runner/tasks/secret-file.yml
@@ -7,7 +7,6 @@
   file:
     state: file
     path: "{{ secret_file_path }}"
-    mode: 0400
     owner: root
     group: root
   when:


### PR DESCRIPTION
Previously, every time the bastion.yml playbook was run, the permissions
would change from 0440 to 0400 to 0440. This was caused by the way
setfacl handles ACLs. See RedHat documentation linked in the related
issue for more information.

Additionally, during testing this issue, it was discovered that the
Vagrantfile was creating a symbolic link at /etc/secrets.yml. Since
roles/ansible-runner/tasks/secrets-file.yml checks if /etc/secrets.yml
is a regular file before acting upon it, this caused the permissions
changes to be skipped in Vagrant.

Now, we are only using the acl module to set permissions (although the
file module is still being used to set ownership). We are also now
copying the file from /vagrant/secrets.yml to /etc/secrets.yml in
Vagrant.

Related-Issue: BonnyCI/projman#154
Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>