### PR TITLE
Add new role for standup-webapp, and add to quartermaster playbook

### DIFF
--- a/quartermaster.yml
+++ b/quartermaster.yml
@@ -16,4 +16,42 @@
     - role: quartermaster
       quartermaster_default_channel: "#BonnyCI"
       quartermaster_name: "quartermaster"
+    - role: standup-webapp
+      standup_database_path: /var/lib/quartermaster/plugins/standup.sqlite
+    - role: uwsgi
+      uwsgi_apt_plugins:
+        - uwsgi-plugin-python
+      uwsgi_vassals:
+        - name: standup 
+          state: present
+          config:
+            uid: www-data
+            gid: www-data
+            wsgi-file: "/opt/source/standup-webapp/wsgi.py"
+            virtualenv: "/opt/venvs/standup-webapp"
+            plugin: python
+            socket: localhost:3312
+            lazy-apps: true
+    - role: apache
+      apache_apt_install:
+        - libapache2-mod-proxy-uwsgi
+      apache_mods_enabled:
+        - proxy.conf
+        - proxy.load
+        - proxy_http.load
+        - proxy_uwsgi.load
+      apache_vhosts:
+      - name: standup
+        vhost_extra: |
+          ErrorLog /var/log/apache2/standup-error.log
+          LogLevel warn
+          CustomLog /var/log/apache2/standup-access.log combined
+
+          ProxyPass "/standups/" uwsgi://localhost:3312/
+
+          Redirect permanent /standups /standups/
+
+          <Directory /var/www/standup>
+            Require all granted
+          </Directory>
 

--- a/roles/standup-webapp/defaults/main.yml
+++ b/roles/standup-webapp/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+standup_git_repo_url: https://github.com/bonnyci/standup-webapp
+standup_git_branch: master
+standup_git_update: yes
+

--- a/roles/standup-webapp/meta/main.yml
+++ b/roles/standup-webapp/meta/main.yml
@@ -1,0 +1,9 @@
+---
+dependencies:
+  - role: python-app
+    name: standup-webapp
+    python_app_pipdeps:
+      - name: Flask
+    python_app_git_repo: "{{ standup_git_repo_url }}"
+    python_app_git_update: "{{ standup_git_update }}"
+    python_app_git_version: "{{ standup_git_branch }}"

--- a/roles/standup-webapp/tasks/main.yml
+++ b/roles/standup-webapp/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+
+- name: Create log directory
+  file:
+    path: /var/log/standup-webapp
+    state: directory
+    mode: 0755
+    owner: www-data
+    group: www-data
+
+- name: Create config directory
+  file:
+    path: /etc/standup
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
+
+- name: Create config file
+  template:
+    src: etc/standup/standup.cfg
+    dest: /etc/standup/standup.cfg
+    owner: www-data

--- a/roles/standup-webapp/templates/etc/standup/standup.cfg
+++ b/roles/standup-webapp/templates/etc/standup/standup.cfg
@@ -1,0 +1,1 @@
+DATABASE='{{ standup_database_path }}'


### PR DESCRIPTION
This role installs the standup flask app, and serves it via uwsgi + apache.

Signed-off-by: Bradon Kanyid <bradon@kanyid.org>