### PR TITLE
Add a live directory in cron-logs

### DIFF
--- a/roles/ansible-runner/tasks/main.yml
+++ b/roles/ansible-runner/tasks/main.yml
@@ -75,5 +75,11 @@
     owner: root
     group: root
 
+- name: Ensure cron log live path
+  file:
+    state: directory
+    path: /var/www/html/cron-logs/live
+    mode: 0755
+
 - include: runner.yml
   with_items: "{{ ansible_runner_tasks }}"


### PR DESCRIPTION
The cron-logs/live directory is hooked up to tailon, but not many people
know this. If we create a directory here it will show up in the index
and apache should redirect correctly to it.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>