### PR TITLE
Reduce min-ready to 1 for both labels

### DIFF
--- a/inventory/group_vars/opentech-sjc
+++ b/inventory/group_vars/opentech-sjc
@@ -35,12 +35,12 @@ nodepool_providers:
 nodepool_labels:
   - name: ubuntu-xenial
     image: ubuntu-xenial
-    min-ready: 3
+    min-ready: 1
     providers:
       - name: cicloud
   - name: ubuntu-hoist
     image: ubuntu-xenial
-    min-ready: 2
+    min-ready: 1
     subnodes: 3
     ready-script: subnode-ssh.sh
     providers:


### PR DESCRIPTION
Since we have a small cloud quota, it's easy for the ubuntu-hoist label
to take up all of our resources since it uses multiple nodes, leaving us
with no ubuntu-xenial nodes ready. Drop both min-ready counts to 1 to make
it more likely that we will ready nodes of both labels.

This means we may spend more time waiting for nodes to build.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>