### PR TITLE
Double our max-servers count

### DIFF
--- a/inventory/group_vars/opentech-sjc
+++ b/inventory/group_vars/opentech-sjc
@@ -20,7 +20,7 @@ nodepool_mysql_host: zuul.internal.opentechsjc.bonnyci.org
 nodepool_providers:
   - name: cicloud
     cloud: opentech-sjc
-    max-servers: 10
+    max-servers: 20
     networks:
       - name: 'nodepool'
         public: True


### PR DESCRIPTION
Now that we have cpu overcommit on, we can run twice as many nodes.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>