### PR TITLE
Fixup deprecation warnings from Ansible

### DIFF
--- a/roles/apache/tasks/apache.yml
+++ b/roles/apache/tasks/apache.yml
@@ -44,7 +44,7 @@
 
 - name: set-up ssl if any vhosts require it
   include: ssl.yml
-  when:  "{{ apache_vhosts | selectattr('ssl', 'defined') | map(attribute='ssl') | sum }}"
+  when: apache_vhosts | selectattr('ssl', 'defined') | map(attribute='ssl') | sum
 
 - name: set-up apache vhosts
   include: vhosts.yml

--- a/roles/bastion/tasks/main.yml
+++ b/roles/bastion/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Add sudo group
   group:
     name: sudo
-  when: "{{ bastion_sudo_users }}"
+  when: bastion_sudo_users
 
 - name: Ensure /etc/sudoers.d/ is included in /etc/sudoers
   lineinfile:
@@ -9,7 +9,7 @@
     line: '#includedir /etc/sudoers.d'
     state: present
     validate: 'visudo -cf %s'
-  when: "{{ bastion_users }}"
+  when: bastion_users
 
 - name: Ensure sudo group has NOPASSWD sudo privileges
   lineinfile:
@@ -17,7 +17,7 @@
     regexp: '^%sudo'
     line: '%sudo  ALL=(ALL:ALL) NOPASSWD:ALL'
     validate: 'visudo -cf %s'
-  when: "{{ bastion_sudo_users }}"
+  when: bastion_sudo_users
 
 - name: Create bastion_users
   user:

--- a/roles/cloud-bootstrap/tasks/accounts.yml
+++ b/roles/cloud-bootstrap/tasks/accounts.yml
@@ -74,7 +74,7 @@
     group: "{{ prod_admin_group }}"
     user: "{{ item.username }}"
   with_items: "{{ users }}"
-  when: "{{ item.isadmin | default('False') | bool }}"
+  when: item.isadmin | default('False') | bool
 
 - name: Grant prod_admin group admin role on prod project
   os_user_role:

--- a/roles/cloud-bootstrap/tasks/network.yml
+++ b/roles/cloud-bootstrap/tasks/network.yml
@@ -63,5 +63,5 @@
     remote_ip_prefix: "{{ item.controlplane_network_cidr }}"
     auth:
       project_name: "{{ item.name }}"
-  when: "{{ split_tenants | bool }}"
+  when: split_tenants | bool
   with_items: "{{ prod_nodepool_projects }}"

--- a/roles/nodepool/tasks/nodepool_v2.yml
+++ b/roles/nodepool/tasks/nodepool_v2.yml
@@ -33,7 +33,7 @@
 - name: Enable and start systemd service
   service:
     enabled: yes
-    state: running
+    state: started
     service: "{{ item }}"
   with_items:
     - nodepool-builder

--- a/roles/nodepool/tasks/nodepool_v3.yml
+++ b/roles/nodepool/tasks/nodepool_v3.yml
@@ -29,7 +29,7 @@
 - name: Enable and start systemd service
   service:
     enabled: yes
-    state: running
+    state: started
     service: "{{ item }}"
   with_items:
     - nodepool-builder

--- a/roles/python-app/tasks/main.yml
+++ b/roles/python-app/tasks/main.yml
@@ -25,13 +25,13 @@
     virtualenv: "{{ python_app_venv_path }}/{{ name }}"
     state: "{{ item.state | default(omit) }}"
   with_items: "{{ python_app_pipdeps }}"
-  when: "{{ item.when | default(True) }}"
+  when: item.when | default(True)
 
 - name: Set python-app venv fact
   set_fact: >
     {{ name | replace('-', '_') }}_venv_path={{ python_app_venv_path }}/{{ name }}
 
-- when: "{{ python_app_git_repo | length > 0 }}"
+- when: python_app_git_repo | length > 0
   block:
     - name: Checkout source
       git:

--- a/roles/zuul/meta/main.yml
+++ b/roles/zuul/meta/main.yml
@@ -6,7 +6,7 @@ dependencies:
       - name: ansible
       - name: statsd
       - name: git+https://github.com/sigmavirus24/github3.py.git@8e9ca0056b8fed956b66dafb5398757cd8d8bed9#egg=Github3.py
-        when: "{{ not zuul_zuul_v3 }}"
+        when: not zuul_zuul_v3
     python_app_git_repo: "{{ zuul_git_repo_url }}"
     python_app_git_version: "{{ zuul_git_branch }}"
     python_app_notify: Restart zuul


### PR DESCRIPTION
When statements should not use jinja brackets.
state: started is deprecated.

Signed-off-by: Jesse Keating <jkeating@j2solutions.net>