### PR TITLE
Move most qm config to secrets, externalize standup config

### DIFF
--- a/quartermaster.yml
+++ b/quartermaster.yml
@@ -14,10 +14,7 @@
 
     - role: common
     - role: quartermaster
-      quartermaster_default_channel: "#BonnyCI"
-      quartermaster_name: "quartermaster"
     - role: standup-webapp
-      standup_database_path: /var/lib/quartermaster/plugins/standup.sqlite
     - role: uwsgi
       uwsgi_apt_plugins:
         - uwsgi-plugin-python
@@ -54,4 +51,3 @@
           <Directory /var/www/standup>
             Require all granted
           </Directory>
-

--- a/roles/quartermaster/templates/config.py
+++ b/roles/quartermaster/templates/config.py
@@ -19,7 +19,7 @@ BOT_ADMINS = ('{{ secrets.quartermaster.admins }}', )
 # !! Don't leave that as "CHANGE ME" if you connect your bot to a chat system!
 
 BOT_IDENTITY = {
-    'nickname': '{{ quartermaster_name }}',
+    'nickname': '{{ secrets.quartermaster.nickname }}',
     # 'username' : 'err-chatbot',    # opt, defaults to nickname if omitted
     # 'password' : None,             # optional
     'server': 'irc.freenode.net',
@@ -35,7 +35,7 @@ BOT_IDENTITY = {
     # 'bind_address': ('localhost', 0),
 }
 
-CHATROOM_PRESENCE = ('{{ quartermaster_default_channel }}', )
+CHATROOM_PRESENCE = ('{{ secrets.quartermaster.default_channel }}', )
 
 IRC_CHANNEL_RATE = 1
 IRC_PRIVATE_RATE = 1

--- a/roles/standup-webapp/tasks/main.yml
+++ b/roles/standup-webapp/tasks/main.yml
@@ -16,8 +16,16 @@
     owner: root
     group: root
 
-- name: Create config file
+- name: Create old config file
   template:
     src: etc/standup/standup.cfg
     dest: /etc/standup/standup.cfg
     owner: www-data
+  when: secrets.quartermaster.standup_settings is defined
+
+- name: Create new config file
+  template:
+    src: etc/standup/config.yaml
+    dest: /etc/standup/config.yaml
+    owner: www-data
+  when: secrets.quartermaster.standup_settings is defined

--- a/roles/standup-webapp/templates/etc/standup/config.yaml
+++ b/roles/standup-webapp/templates/etc/standup/config.yaml
@@ -1,0 +1,1 @@
+{{ secrets.quartermaster.standup_settings }}

--- a/roles/standup-webapp/templates/etc/standup/standup.cfg
+++ b/roles/standup-webapp/templates/etc/standup/standup.cfg
@@ -1,1 +1,1 @@
-DATABASE='{{ standup_database_path }}'
+DATABASE='{{ secrets.quartermaster.standup_settings.database_path }}'

--- a/secrets.yml.example
+++ b/secrets.yml.example
@@ -2,6 +2,22 @@ secrets:
   quartermaster:
     admins: nick!~username@domain.org
     nickserv_pass: nickserv_pass
+    default_channel: "#BonnyCI-errbot"
+    nickname: "errbot-qm"
+    standup_settings:
+      database_path: /var/lib/quartermaster/plugins/standup.sqlite
+      local_notification_hour: 10
+      timezones:
+        - timezone: 'Australia/Sydney'
+          users:
+            - aussieuser
+        - timezone: 'America/New_York'
+          users:
+            - eastcoastuser
+        - timezone: 'America/Los_Angeles'
+          users:
+            - westcoastuser1
+            - westcoastuser2
   db_password: changeme
   nodepool:
     db_user: nodepool


### PR DESCRIPTION
The standup feature of quartermaster now has an external config file,
which needs to be generated by hoist during installation. I've also
moved a few of quartermaster's config settings to secrets.

This needs merged before I pull the trigger on the errbot plugin side.

Signed-off-by: Bradon Kanyid <bradon@kanyid.org>