### PR TITLE
Add apache logs to ELK

### DIFF
--- a/bastion.yml
+++ b/bastion.yml
@@ -33,4 +33,12 @@
       when: secrets is defined
     - role: ansible-runner
       ansible_runner_minute: "*/15"
+    - role: filebeat
+      filebeat_prospectors:
+        - name: apache
+          prospectors:
+            - input_type: log
+              document_type: apache
+              paths:
+                - /var/log/apache/*.log
     - role: fail2ban  # This should be last

--- a/install-ci.yml
+++ b/install-ci.yml
@@ -121,6 +121,12 @@
                 match: after
                 negate: true
                 pattern: '^[0-9]{4}-[0-9]{2}-[0-9]{2}'
+        - name: apache
+          prospectors:
+            - input_type: log
+              document_type: apache
+              paths:
+                - /var/log/apache/*.log
 
 - name: Install zuul mergers
   hosts: mergers
@@ -166,6 +172,12 @@
                 match: after
                 negate: true
                 pattern: '^[0-9]{4}-[0-9]{2}-[0-9]{2}'
+        - name: apache
+          prospectors:
+            - input_type: log
+              document_type: apache
+              paths:
+                - /var/log/apache/*.log
 
 - name: Install nodepool
   hosts: nodepool
@@ -247,6 +259,15 @@
     - role: dd-apache
       tags:
         - monitoring
+
+    - role: filebeat
+      filebeat_prospectors:
+        - name: apache
+          prospectors:
+            - input_type: log
+              document_type: apache
+              paths:
+                - /var/log/apache/*.log
 
 # This task needs to be done last because fail2ban will fail to start
 # if the configured log files to scan do not exist yet.

--- a/inventory/host_vars/bastion.opentechsjc.bonnyci.org
+++ b/inventory/host_vars/bastion.opentechsjc.bonnyci.org
@@ -27,3 +27,6 @@ ansible_runner_tasks:
       ansible_remote_user: ubuntu
 
 dns_subdomain: internal.opentechsjc.bonnyci.org
+
+filebeat_output_logstash_hosts:
+  - elk.internal.opentechsjc.bonnyci.org:5044


### PR DESCRIPTION
Logstash ships with a filter for apache logs, so setting the
document_type to 'apache' is enough to get those logs parsed.