### PR TITLE
Replace anne-bonny user with bonnyci[bot] in layout

### DIFF
--- a/roles/zuul/templates/etc/zuul/config/layout.yaml
+++ b/roles/zuul/templates/etc/zuul/config/layout.yaml
@@ -38,13 +38,13 @@ pipelines:
     trigger:
       github:
         - event: status
-          status: "anne-bonny:check_github:success"
+          status: "bonnyci[bot]:check_github:success"
         - event: pr-review
           state: 'approved'
         - event: pr-comment
           comment: (?i)^\s*gate-recheck\s*$
     require:
-      status: "anne-bonny:check_github:success"
+      status: "bonnyci[bot]:check_github:success"
       approval:
         - review: 2
     reject:


### PR DESCRIPTION
When using the integration our CI user is going to be bonnyci[bot]
instead of anne-bonny. With the dependant transition patch we are faking
the anne-bonny user into providing bonnyci[bot] reviews, however this
means we need to have our layout reflect the new user.

Depends-On: BonnyCI/zuul#39
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>