### PR TITLE
Add nodepool image builds to the end of the restart playbook

### DIFF
--- a/inventory/group_vars/vagrant
+++ b/inventory/group_vars/vagrant
@@ -13,6 +13,17 @@ elasticsearch_jvm_heap_size: 250m
 filebeat_output_logstash_hosts:
   - elk.vagrant:5044
 
+nodepool_labels:
+  - name: ubuntu-xenial
+    image: ubuntu-xenial
+    min-ready: 1
+    providers:
+      - name: cicloud
+  - name: ubuntu-xenial-alt
+    image: ubuntu-xenial
+    min-ready: 1
+    providers:
+      - name: cicloud
 nodepool_providers:
   - name: cicloud
     cloud: cicloud

--- a/restart.yml
+++ b/restart.yml
@@ -56,3 +56,7 @@
         - nodepool-builder
         - nodepool-deleter
         - nodepool-launcher
+
+    - name: Rebuild nodepool images
+      command: "/opt/venvs/nodepool/bin/nodepool image-build {{ item }}"
+      with_items: "{{ nodepool_labels | map(attribute='image') | list | unique }}"


### PR DESCRIPTION
Also add nodepool_labels to the vagrant group_vars for testing this.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>