### PR TITLE
Add a way to disable the ansible-runners from ansible

### DIFF
--- a/roles/ansible-runner/defaults/main.yml
+++ b/roles/ansible-runner/defaults/main.yml
@@ -1,6 +1,7 @@
 ansible_runner_user: root
 ansible_runner_secrets_path: /etc/secrets.yml
 ansible_runner_virtualenv: /opt/ansible
+ansible_runner_disabled: False
 datadog_callback_url: https://raw.githubusercontent.com/DataDog/ansible-datadog-callback/master/datadog_callback.py
 
 # Example:

--- a/roles/ansible-runner/tasks/runner.yml
+++ b/roles/ansible-runner/tasks/runner.yml
@@ -33,6 +33,12 @@
   secret_file_path: "{{ ansible_runner_secrets_path }}"
   secret_file_user: "{{ item.user }}"
 
+- name: Disable cron job
+  copy:
+    content: ""
+    dest: "/etc/disable-ansible-runner-{{ item.name }}"
+  when: item.disabled | default(ansible_runner_disabled)
+
 - name: Ensure cron log path
   file:
     state: directory


### PR DESCRIPTION
Add a disable flag that disables the ansible-runner from running on
cron. This is useful for testing where I don't want all the runners to
actually start.

I haven't added the reverse that removes the flag from git as I feel you
probably want to control this manually so the automation doesn't remove
your manual hold.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>