### PR TITLE
We need to run nodepool as the nodepool user

### DIFF
--- a/restart.yml
+++ b/restart.yml
@@ -57,6 +57,13 @@
         - nodepool-deleter
         - nodepool-launcher
 
+- name: Build new nodepool images
+  hosts: nodepool
+  become: yes
+  become_user: nodepool
+  tags:
+    - nodepool
+  tasks:
     - name: Rebuild nodepool images
       command: "/opt/venvs/nodepool/bin/nodepool image-build {{ item }}"
       with_items: "{{ nodepool_labels | map(attribute='image') | list | unique }}"


### PR DESCRIPTION
We can't access the clouds.yaml secrets unless we run the command as
the nodepool user.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>