### PR TITLE
Add dib image build test to hoist

### DIFF
--- a/roles/zuul/files/jobs/dib.yaml
+++ b/roles/zuul/files/jobs/dib.yaml
@@ -1,0 +1,26 @@
+- job:
+    name: 'dib-build'
+    node: 'ubuntu-xenial'
+    builders:
+      shell: |
+        virtualenv $HOME/dib-build
+        source $HOME/dib-build/bin/activate
+        pip install diskimage-builder
+
+        sudo apt-get install -y debootstrap qemu-utils curl \
+                                uuid-runtime parted kpartx
+
+        sudo git clone https://github.com/BonnyCI/hoist.git /opt/hoist
+        export ELEMENTS_PATH=/opt/hoist/roles/nodepool/files/etc/nodepool/elements/nodepool
+        # NOTE: be sure the list of nodepool elements here stays consistent
+        # with the elements specified in the nodepool role.
+        sudo disk-image-create -x -t qcow2 --checksum --no-tmpfs            \
+                          --qemu-img-options 'compat=0.10'                  \
+                          -o /opt/nodepool/images/ubuntu-xenial             \
+                          ubuntu-minimal vm simple-init growroot            \
+                          openssh-server devuser haveged pip-and-virtualenv \
+                          nodepool bonnyci-nodepool
+
+    publishers:
+      - console-log
+      - bonnyci-logs

--- a/roles/zuul/templates/etc/zuul/config/layout.yaml
+++ b/roles/zuul/templates/etc/zuul/config/layout.yaml
@@ -69,6 +69,8 @@ jobs:
   # every job invokes the set_node_options file in bonnyci_functions.py
   - name: ^.*$
     parameter-function: set_node_options
+  - name: dib-build
+    files: roles/nodepool/files/etc/nodepool/elements/*
 
 projects:
   - name: BonnyCI/bonnyci.org
@@ -92,8 +94,10 @@ projects:
   - name: BonnyCI/hoist
     check_github:
       - bonnyci-run-check-multinode
+      - dib-build
     gate_github:
       - bonnyci-run-gate-multinode
+      - dib-build
 
   - name: BonnyCI/sandbox
     check_github:


### PR DESCRIPTION
Currently, we have no tests for dib image builds using the elements
defined in hoist. This results in untested image builds ending up
in prod. This will add a job for that.

Implements: BonnyCI/projman#219

Signed-off-by: Cullen Taylor <cullentaylor@outlook.com>