### PR TITLE
Add default PATH to crontab

### DIFF
--- a/roles/ansible-runner/tasks/runner.yml
+++ b/roles/ansible-runner/tasks/runner.yml
@@ -41,6 +41,12 @@
     owner: "{{ item.user }}"
     group: www-data
 
+- name: Add default PATH to cron file
+  cron:
+    name: PATH
+    env: yes
+    value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
 - name: Add ansible-runner cron job
   cron:
     name: "ansible-runner deploy {{ item.name}}"


### PR DESCRIPTION
Root cron, in particular, has a severely limited default PATH. This
lead to apt not being able to find dependencies when attempting to
install new packages.

This adds a more sane default path to crontab files, to fix that
problem.

Signed-off-by: Bradon Kanyid <bradon@kanyid.org>