### PR TITLE
Fix an issue with cron PATH only being set for root

### DIFF
--- a/roles/ansible-runner/tasks/runner.yml
+++ b/roles/ansible-runner/tasks/runner.yml
@@ -45,6 +45,7 @@
   cron:
     name: PATH
     env: yes
+    user: "{{ item.user }}"
     value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 - name: Add ansible-runner cron job


### PR DESCRIPTION
I forgot to specify the user, so it defaults to ansible's user, which
is 'become: yes', so it's always root.

Signed-off-by: Bradon Kanyid <bradon@kanyid.org>