### PR TITLE
Add pruner script to ARA role

### DIFF
--- a/roles/ara/defaults/main.yml
+++ b/roles/ara/defaults/main.yml
@@ -1,0 +1,4 @@
+# Keep 7 days worth of ARA data
+ara_prune_days: 7
+#Run offset from ansible-runner :07,:22,:37,:52
+ara_prune_cron_schedule: 7,22,37,52

--- a/roles/ara/files/usr/local/bin/ara-prune
+++ b/roles/ara/files/usr/local/bin/ara-prune
@@ -1,0 +1,32 @@
+#!/bin/bash -eu
+
+if [[ -z ${1+x} ]]; then
+  echo "ERROR: Must supply argument for # of days to keep"
+  exit 1
+else
+  days_to_keep="$1"
+fi
+
+ara_venv=${ANSIBLE_RUNNER_VENV:-/opt/ansible}
+
+set +u
+. "$ara_venv"/bin/activate
+set -u
+
+# Get all the playbooks IDs and dates in csv format, no surrounding quotes, skip the header
+playbooks=$(ara playbook list -c "ID" -c "Time Start" -f "csv" --quote "none" | tail -n +2) 
+
+# Get a week ago in seconds from epoch
+date_to_prune=$(date --date="$days_to_keep days ago" +%s)
+
+printf '%s\n' "$playbooks" | while IFS= read -r line; 
+do
+  id=$(echo "$line" | cut -f1 -d,)
+  # Convert the date from ARA into an epoch date for comparison
+  line_date=$(echo "$line" | cut -f2 -d,) 
+  date_in_secs=$(date -d "$line_date" +%s)
+  if [ "$date_in_secs" -le "$date_to_prune" ]; then
+    # Remove old playbooks
+    ara playbook delete "$id"
+  fi
+done

--- a/roles/ara/tasks/main.yml
+++ b/roles/ara/tasks/main.yml
@@ -16,6 +16,7 @@
     - libffi-dev
     - python-dev
     - libssl-dev
+    - cron
 
 - name: Install ara
   pip:
@@ -70,3 +71,17 @@
     group: www-data
     recurse: yes
 
+- name: Copy ara-prune script into place
+  copy:
+    src: usr/local/bin/ara-prune
+    dest: /usr/local/bin/ara-prune
+    mode: 0755
+    owner: root
+    group: root
+
+- name: Add ara-prune cron job
+  cron:
+    name: "ara-prune"
+    minute: "{{ ara_prune_cron_schedule | default(omit) }}"
+    user: root
+    job: "/usr/local/bin/ara-prune {{ ara_prune_days }}"


### PR DESCRIPTION
ARA currently is saving entries to a sqlite db on the bastion. We run
ansible *a lot* so this database is getting quite large. This script
uses ARA's cli tool to determine ara playbooks older than a certain
date, and deletes them from the database.

This is a stop-gap solution until I move the ARA database to mysql on
the logs host.

Signed-off-by: Bradon Kanyid <bradon@kanyid.org>