### PR TITLE
Enable SSL on the bastion apache

### DIFF
--- a/bastion.yml
+++ b/bastion.yml
@@ -14,6 +14,10 @@
       tags:
         - monitoring
       when: secrets is defined
+    - role: letsencrypt
+      tags:
+        - letsencrypt
+      when: letsencrypt_csr_cn | default(False)
     - bastion
     - role: datadog-builder
       datadog_builder_secrets:
@@ -73,6 +77,10 @@
         - name: bastion
           document_root: /var/www/html/
           document_root_options: +FollowSymLinks
+          ssl: "{{ letsencrypt_csr_cn | default(False) | bool }}"
+          certificate_file: "{{ letsencrypt_cert_path | default('') }}"
+          certificate_key_file: "{{ letsencrypt_key_path | default('') }}"
+          certificate_chain_file: "{{ letsencrypt_chain_path | default('') }}"
           vhost_extra: |
             AddType text/plain .log
 

--- a/inventory/host_vars/bastion.opentechsjc.bonnyci.org
+++ b/inventory/host_vars/bastion.opentechsjc.bonnyci.org
@@ -28,5 +28,7 @@ ansible_runner_tasks:
 
 dns_subdomain: internal.opentechsjc.bonnyci.org
 
+letsencrypt_csr_cn: bastion.opentechsjc.bonnyci.org
+
 filebeat_output_logstash_hosts:
   - elk.internal.opentechsjc.bonnyci.org:5044


### PR DESCRIPTION
We're serving ARA, cron logs and other things on apache on the bastion.
As with all our other servers this should be done over SSL.

Again there's no real way to test this except on prod so only approve
when someone is there to shepherd it through.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>