### PR TITLE
Add logging-proxy deployment to logs server

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -251,6 +251,20 @@
             socket: localhost:3310
             lazy-apps: true
 
+    - role: logging-proxy
+      logging_proxy_host: 127.0.0.1
+
+    - role: logrotate
+      logrotate_configs:
+        - name: zuul
+          path: /var/log/logging-proxy/*log
+          options:
+            - compress
+            - missingok
+            - rotate 30
+            - daily
+            - notifempty
+
     - role: apache
       apache_apt_install: "{{ bonnyci_logs_apache_apt_install }}"
       apache_mods_enabled: "{{ bonnyci_logs_apache_mods_install }}"

--- a/inventory/group_vars/log
+++ b/inventory/group_vars/log
@@ -5,6 +5,8 @@ bonnyci_logs_apache_mods_install:
   - rewrite.load
   - proxy.load
   - proxy_uwsgi.load
+  - proxy_http.load
+  - proxy_wstunnel.load
 
 bonnyci_logs_apache_vhosts:
   - name: logs
@@ -73,6 +75,15 @@ bonnyci_logs_apache_vhosts:
       ProxyPass /htmlify/ uwsgi://localhost:3310/
 
       ServerSignature Off
+
+  - name: logging-proxy
+    port: 3001
+    server_name: "{{ bonnyci_logs_apache_server_name | default('logs') }}"
+    aliases: "{{ bonnyci_logs_apache_server_aliases | default([]) }}"
+
+    vhost_extra: |
+      ProxyPass /sock ws://localhost:3000/sock
+      ProxyPass / http://localhost:3000/
 
 bonnyci_logs_loganalyze_file_conditions:
   - filename_pattern: ^.*\.txt(\.gz)?$

--- a/roles/logging-proxy/defaults/main.yml
+++ b/roles/logging-proxy/defaults/main.yml
@@ -1,0 +1,12 @@
+logging_proxy_port: 3000
+logging_proxy_host: "0.0.0.0"
+
+logging_proxy_nodejs_path: /usr/bin/nodejs
+
+logging_proxy_git_repo: https://github.com/BonnyCI/logging-proxy.git
+logging_proxy_git_version: master
+logging_proxy_git_force: no
+logging_proxy_git_update: no
+
+logging_proxy_service_enabled: yes
+logging_proxy_service_restart: always

--- a/roles/logging-proxy/handlers/main.yml
+++ b/roles/logging-proxy/handlers/main.yml
@@ -1,0 +1,12 @@
+- name: Reload systemd unit files
+  command: systemctl daemon-reload
+
+- name: Restart rsyslog
+  service:
+    name: rsyslog
+    state: restarted
+
+- name: Restart logging-proxy
+  service:
+    name: logging-proxy
+    state: restarted

--- a/roles/logging-proxy/tasks/main.yml
+++ b/roles/logging-proxy/tasks/main.yml
@@ -1,0 +1,82 @@
+---
+- name: Nodesource apt key
+  apt_key:
+    url: "https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
+    state: present
+
+- name: Install nodesource repos
+  apt_repository:
+    repo: deb https://deb.nodesource.com/node_6.x xenial main
+    state: present
+    filename: nodesource
+    update_cache: yes
+
+- name: Install packages
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - git
+    - nodejs
+
+- name: Create user
+  user:
+    name: "{{ logging_proxy_user }}"
+    home: "/var/lib/{{ logging_proxy_user }}"
+    createhome: yes
+
+- name: Clone source
+  become: yes
+  become_user: "{{ logging_proxy_user }}"
+  git:
+    dest: "{{ logging_proxy_source }}"
+    repo: "{{ logging_proxy_git_repo }}"
+    version: "{{ logging_proxy_git_version }}"
+    update: "{{ logging_proxy_git_update }}"
+    force: "{{ logging_proxy_git_force }}"
+  register: logging_proxy_source_changed
+  notify: Restart logging-proxy
+
+- name: Install npm dependencies
+  become: yes
+  become_user: "{{ logging_proxy_user }}"
+  npm:
+    global: no
+    production: yes
+    state: latest
+    path: "{{ logging_proxy_source }}"
+  when: logging_proxy_source_changed.changed
+  notify: Restart logging-proxy
+
+- name: Copy defaults file
+  template:
+    src: etc/default/bonnyci-logging-proxy
+    dest: /etc/default/bonnyci-logging-proxy
+  notify: Restart logging-proxy
+
+- name: Copy service unit file
+  template:
+    src: etc/systemd/system/logging-proxy.service
+    dest: /etc/systemd/system/logging-proxy.service
+  notify: Reload systemd unit files
+
+- name: Create logging directory
+  file:
+    state: directory
+    name: "{{ logging_proxy_log_dir }}"
+    group: syslog
+    mode: 0775
+
+- name: Copy rsyslog handling
+  template:
+    src: etc/rsyslog.d/45-logging-proxy.conf
+    dest: /etc/rsyslog.d/45-logging-proxy.conf
+  notify: Restart rsyslog
+
+- meta: flush_handlers
+
+- name: Enable service
+  service:
+    name: logging-proxy
+    state: started
+    enabled: "{{ logging_proxy_service_enabled }}"

--- a/roles/logging-proxy/templates/etc/default/bonnyci-logging-proxy
+++ b/roles/logging-proxy/templates/etc/default/bonnyci-logging-proxy
@@ -1,0 +1,2 @@
+NODE_PORT = {{ logging_proxy_port }}
+NODE_HOST = {{ logging_proxy_host }}

--- a/roles/logging-proxy/templates/etc/rsyslog.d/45-logging-proxy.conf
+++ b/roles/logging-proxy/templates/etc/rsyslog.d/45-logging-proxy.conf
@@ -1,0 +1,2 @@
+:programname, isequal, "{{ logging_proxy_syslog_identifier }}" -{{ logging_proxy_log_dir }}/logging-proxy.log
+& stop

--- a/roles/logging-proxy/templates/etc/systemd/system/logging-proxy.service
+++ b/roles/logging-proxy/templates/etc/systemd/system/logging-proxy.service
@@ -1,0 +1,15 @@
+[Unit]
+Description = BonnyCI Logging Proxy Service
+After = network.target
+
+[Service]
+Type=simple
+User={{ logging_proxy_user }}
+EnvironmentFile=-/etc/default/bonnyci-logging-proxy
+WorkingDirectory={{ logging_proxy_home }}
+ExecStart={{ logging_proxy_nodejs_path }} {{ logging_proxy_source }}/{{ logging_proxy_entrypoint }}
+Restart={{ logging_proxy_service_restart }}
+SyslogIdentifier={{ logging_proxy_syslog_identifier }}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/logging-proxy/vars/main.yml
+++ b/roles/logging-proxy/vars/main.yml
@@ -1,0 +1,7 @@
+logging_proxy_user: logging-proxy
+logging_proxy_home: "/var/lib/{{ logging_proxy_user }}"
+logging_proxy_source: "{{ logging_proxy_home }}/logging-proxy"
+logging_proxy_entrypoint: index.js
+
+logging_proxy_syslog_identifier: bonnyci-logging-proxy
+logging_proxy_log_dir: /var/log/logging-proxy


### PR DESCRIPTION
At the moment we deploy the logging proxy onto the log server on a high
port. We don't need to expose this on a standard port for now because
people will only follow links. In future the client side of this can be
integrated into the bonnyci.org site and the websock be on whatever port
we like. For now splitting that up is not worth it.

I've set up the proxy so that it redirects through apache so that when
we put SSL on the site this will also be affected.

There's some logging magic in here to get from journald -> syslog ->
file so we can later put it into logstash.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>