### PR TITLE
Stop install pip datadog to /opt/datadog

### DIFF
--- a/roles/dd-agent/tasks/main.yml
+++ b/roles/dd-agent/tasks/main.yml
@@ -23,14 +23,6 @@
   notify:
     - restart dd-agent
 
-# This is required to call datadog_monitor with ansible and later to use the
-# datadog callback for more integration into ansible runs
-# within datadog.
-- name: install datadog pip
-  pip:
-    name: datadog
-    virtualenv: /opt/datadog
-
 - name: Ensure config directories
   file:
     state: directory


### PR DESCRIPTION
I think this is a remnant of some earlier attempt at ansible datadog
integration, however ansible gets installed into /opt/ansible and there
is no other reference to this directory I can find in hoist.

I don't think it's required any more.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>