### PR TITLE
Add a docker and logging-proxy role

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,0 +1,41 @@
+# The ansible version of https://docs.docker.com/engine/installation/linux/ubuntu/
+---
+- name: Remove older package names
+  apt:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - docker
+    - docker-engine
+
+- name: Install requirements
+  apt:
+    name: linux-image-extra-virtual
+    state: present
+
+- name: Install apt key
+  apt_key:
+    id: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
+    url: https://download.docker.com/linux/ubuntu/gpg
+    state: present
+
+- name: Add repo
+  apt_repository:
+    repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+    state: present
+    filename: docker
+    update_cache: yes
+
+- name: Install docker
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - docker-ce
+    - python-docker
+
+- name: Start docker
+  service:
+    name: docker
+    state: started
+    enabled: yes

--- a/roles/logging-proxy/defaults/main.yml
+++ b/roles/logging-proxy/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+logging_proxy_tag: latest
+logging_proxy_host: "0.0.0.0"
+logging_proxy_port: 3000

--- a/roles/logging-proxy/tasks/main.yml
+++ b/roles/logging-proxy/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Fetch and install
+  docker_container:
+    name: logging-proxy
+    image: "quay.io/bonnyci/logging-proxy:{{ logging_proxy_tag }}"
+    ports:
+      - "{{ logging_proxy_host }}:{{ logging_proxy_port }}:3000"
+    state: started
+    pull: yes
+    restart_policy: always
+    network_mode: bridge


### PR DESCRIPTION
Instead of installing nodejs and everything in place go full devops and
docker it. Quay.io can auto build containers on every github push and
then ansible just ensures that the latest container from the repository
is installed and running.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>