### PR TITLE
ansible-runner: Drop flag files for failing environments

### DIFF
--- a/roles/ansible-runner/files/usr/local/bin/ansible-runner
+++ b/roles/ansible-runner/files/usr/local/bin/ansible-runner
@@ -1,6 +1,8 @@
 #!/bin/bash -eu
 # Runs system wide ansible configured in /etc
 
+set -o pipefail
+
 env=$1
 shift
 if [ -f /etc/default/"$env" ]; then
@@ -10,6 +12,7 @@ fi
 envs_root=${ANSIBLE_RUNNER_ENV_ROOT:-/opt/source}
 ansible_venv=${ANSIBLE_RUNNER_VENV:-/opt/ansible}
 log_dir=${ANSIBLE_RUNNER_LOG_DIR:-/var/www/html/cron-logs/$env/}
+failing_dir=${ANSIBLE_RUNNER_FAILING_DIR:-/var/www/html/cron-logs/failing/}
 ssh_user=${ANSIBLE_SSH_USER:-""}
 force_runner=false
 ansible_options=""
@@ -60,7 +63,14 @@ fi
 if [ -n "$ssh_user" ]; then
     ansible_options="$ansible_options -e ansible_ssh_user=$ssh_user"
 fi
-"$ansible_venv"/bin/ansible-playbook -vv -i "$ANSIBLE_INVENTORY" $ansible_options "$ANSIBLE_PLAYBOOK" 2>&1 | tee -a "$logfile"
+
+if ! "$ansible_venv"/bin/ansible-playbook -vv -i "$ANSIBLE_INVENTORY" $ansible_options "$ANSIBLE_PLAYBOOK" 2>&1 | tee -a "$logfile"; then
+  mkdir -p "$failing_dir"
+  touch "${failing_dir}/${env}"
+else
+  rm -rf "${failing_dir}/${env}"
+fi
+
 date 2>&1 | tee -a "$logfile"
 
 # Remove > 10 days old

--- a/tests/files/ansible_runner_test.yml
+++ b/tests/files/ansible_runner_test.yml
@@ -1,7 +1,9 @@
 ---
-- name: Write a test file
+- name: A test playbook
   hosts: localhost
   tasks:
+    - fail:
+      when: fail_test_playbook is defined
     - copy:
         dest: %%TEST_FILE_PATH%%
         content: %%TEST_FILE_CONTENT%%


### PR DESCRIPTION
This updates ansible-runner to drop empty files in a known
directory for environments that are failing to complete their
playbooks. The files are named after the failing environment.
Upon successful ansible run, these files are cleaned up if
they exist.

This'll allow us to set a datadog check that fails when any
files exist here.  Our current datadog check is broken and
relies on log scraping and doesn't really work with multi-env
bastions.

Related-Issue: BonnyCI/projman#224

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>