### PR TITLE
Use explicit bastion ssl flag instead of letsencrypt

### DIFF
--- a/bastion.yml
+++ b/bastion.yml
@@ -77,7 +77,7 @@
         - name: bastion
           document_root: /var/www/html/
           document_root_options: +FollowSymLinks
-          ssl: "{{ letsencrypt_csr_cn | default(False) | bool }}"
+          ssl: "{{ bonnyci_bastion_ssl | default(False) }}"
           certificate_file: "{{ letsencrypt_cert_path | default('') }}"
           certificate_key_file: "{{ letsencrypt_key_path | default('') }}"
           certificate_chain_file: "{{ letsencrypt_chain_path | default('') }}"

--- a/inventory/host_vars/bastion.opentechsjc.bonnyci.org
+++ b/inventory/host_vars/bastion.opentechsjc.bonnyci.org
@@ -28,6 +28,7 @@ ansible_runner_tasks:
 
 dns_subdomain: internal.opentechsjc.bonnyci.org
 
+bonnyci_bastion_ssl: true
 letsencrypt_csr_cn: bastion.opentechsjc.bonnyci.org
 
 filebeat_output_logstash_hosts:


### PR DESCRIPTION
This bit us in zuul as well. We should be able to use the presence of
the letsencrypt variable as an indicator to turn on SSL but the existing
string evaluates as False. Make it explicit. This is annoying because
you need to set 2 flags to turn on SSL.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>