### PR TITLE
Set datadog hostname on elk, logs and bastion

### DIFF
--- a/inventory/host_vars/bastion.opentechsjc.bonnyci.org
+++ b/inventory/host_vars/bastion.opentechsjc.bonnyci.org
@@ -26,6 +26,8 @@ ansible_runner_tasks:
       user: cideploy
       ansible_remote_user: ubuntu
 
+datadog_hostname: bastion.opentechsjc.bonnyci.org
+
 dns_subdomain: internal.opentechsjc.bonnyci.org
 
 letsencrypt_csr_cn: bastion.opentechsjc.bonnyci.org

--- a/inventory/host_vars/elk.internal.opentechsjc.bonnyci.org
+++ b/inventory/host_vars/elk.internal.opentechsjc.bonnyci.org
@@ -1,0 +1,2 @@
+---
+datadog_hostname: elk.internal.opentechsjc.bonnyci.org

--- a/inventory/host_vars/logs.internal.opentechsjc.bonnyci.org
+++ b/inventory/host_vars/logs.internal.opentechsjc.bonnyci.org
@@ -1,3 +1,4 @@
 ---
 letsencrypt_csr_cn: logs.bonnyci.org
 bonnyci_logs_ssl: yes
+datadog_hostname: logs.internal.opentechsjc.bonnyci.org


### PR DESCRIPTION
It looks like datadog is considering bastion and bastion.openstack and
the others as seperate hosts because what is in the ansible inventory
does not match what datadog thinks it is talking to.

Hopefully if we force set the hostname these things will start being
correlated. And I'm not sure if they're being billed as seperate
entities or not.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>