### PR TITLE
Use ansible_hostname as datadog hostname

### DIFF
--- a/bastion.yml
+++ b/bastion.yml
@@ -10,10 +10,13 @@
 
   roles:
     - common
+
     - role: dd-agent
+      datadog_hostname: "{{ datadog_hostname | default(ansible_hostname) }}"
       tags:
         - monitoring
       when: secrets is defined
+
     - role: letsencrypt
       tags:
         - letsencrypt

--- a/install-ci.yml
+++ b/install-ci.yml
@@ -10,6 +10,7 @@
     - role: common
 
     - role: dd-agent
+      datadog_hostname: "{{ datadog_hostname | default(ansible_hostname) }}"
       tags:
         - monitoring
 


### PR DESCRIPTION
I think it's still correct in the dd-agent not to automatically set
hostname because for a lot of cases the system derived hostname is
probably correct. For us who created a lot of short hostnames in
openstack that come through as the hostname in datadog this means that
the datadog ansible hosts don't line up with the actual hosts.

Always default to the ansible set hostname in datadog.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>