### PR TITLE
Add letsencrypt_production to bastion

### DIFF
--- a/inventory/opentech-sjc-common
+++ b/inventory/opentech-sjc-common
@@ -8,6 +8,7 @@ logs.internal.opentechsjc.bonnyci.org
 elk.internal.opentechsjc.bonnyci.org
 
 [production]
+bastion.opentechsjc.bonnyci.org
 logs.internal.opentechsjc.bonnyci.org
 elk.internal.opentechsjc.bonnyci.org
 


### PR DESCRIPTION
By default letsencrypt fetches certs from the staging server. This is
better for testing. We override this to production for everything in the
production group. This should include bastion because we do use it in
production.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>