### PR TITLE
Fix datadog_hostname

### DIFF
--- a/bastion.yml
+++ b/bastion.yml
@@ -12,7 +12,7 @@
     - common
 
     - role: dd-agent
-      datadog_hostname: "{{ datadog_hostname | default(ansible_hostname) }}"
+      datadog_hostname: "{{ ansible_hostname }}"
       tags:
         - monitoring
       when: secrets is defined

--- a/install-ci.yml
+++ b/install-ci.yml
@@ -10,7 +10,7 @@
     - role: common
 
     - role: dd-agent
-      datadog_hostname: "{{ datadog_hostname | default(ansible_hostname) }}"
+      datadog_hostname: "{{ ansible_hostname }}"
       tags:
         - monitoring
 


### PR DESCRIPTION
Appears you can't make ansible call the same variable. I guess that
makes sense because it's not going to be evaluated until it's actually
within the role - but this would be really convenient.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>