### PR TITLE
Set datadog hostname to inventory_hostname

### DIFF
--- a/bastion.yml
+++ b/bastion.yml
@@ -12,7 +12,7 @@
     - common
 
     - role: dd-agent
-      datadog_hostname: "{{ ansible_hostname }}"
+      datadog_hostname: "{{ inventory_hostname }}"
       tags:
         - monitoring
       when: secrets is defined

--- a/install-ci.yml
+++ b/install-ci.yml
@@ -10,7 +10,7 @@
     - role: common
 
     - role: dd-agent
-      datadog_hostname: "{{ ansible_hostname }}"
+      datadog_hostname: "{{ inventory_hostname }}"
       tags:
         - monitoring
 


### PR DESCRIPTION
*sigh* attempt 3 at this. The whole point is to get the names reported
in datadog to match up to those that ansible reports. To do that we need
to match them to things in the inventory.

That requires using inventory_hostname, not ansible_hostname which will
just set them to the same discovered hostname that datadog would anyway.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>