### PR TITLE
Rename project-repos and config-repos in zuul v3

### DIFF
--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -81,9 +81,9 @@ zuul_tenants:
   - name: BonnyV3
     source:
       gerrithub:
-        config-repos:
+        config-projects:
           - BonnyCI/project-config-v3
-        project-repos:
+        untrusted-projects:
           - BonnyCI/sandbox-v3
 
 dns_subdomain: internal.v3.opentechsjc.bonnyci.org


### PR DESCRIPTION
Zuul V3 has renamed config-repos to config-projects and project-repos to
untrusted-projects. Adjust our deployment to follow suit.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>