### PR TITLE
Remove portbleu host_vars

### DIFF
--- a/inventory/host_vars/nodepool.bonnyci-internal.portbleu.com
+++ b/inventory/host_vars/nodepool.bonnyci-internal.portbleu.com
@@ -1,1 +1,0 @@
-zookeeper_myid: 1

--- a/inventory/host_vars/zuul.bonnyci-internal.portbleu.com
+++ b/inventory/host_vars/zuul.bonnyci-internal.portbleu.com
@@ -1,3 +1,0 @@
----
-letsencrypt_csr_cn: zuul.bonnyci.org
-bonnyci_zuul_webapp_ssl: yes


### PR DESCRIPTION
We are no longer running the bonnyci-internal.portbleu.com environment
so we can remove these host vars.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>