### PR TITLE
Fix ara-pruner to find where the ARA db is

### DIFF
--- a/roles/ara/files/usr/local/bin/ara-prune
+++ b/roles/ara/files/usr/local/bin/ara-prune
@@ -8,10 +8,14 @@ else
 fi
 
 ara_venv=${ANSIBLE_RUNNER_VENV:-/opt/ansible}
+env_source="/opt/source/system-ansible"
 
 set +u
 . "$ara_venv"/bin/activate
 set -u
+
+# Need to be in the same directory as ansible.cfg for ARA to know where to find the database
+cd "$env_source"
 
 # Get all the playbooks IDs and dates in csv format, no surrounding quotes, skip the header
 playbooks=$(ara playbook list -c "ID" -c "Time Start" -f "csv" --quote "none" | tail -n +2) 


### PR DESCRIPTION
The ARA cli program looks for ansible.cfg in a few places, and if it
doesn't find it, it uses some defaults and creates a new ARA db.

This leads the ara-pruner script to not be looking at the right
database. This points it at the right place.

Signed-off-by: Bradon Kanyid <bradon@kanyid.org>