### PR TITLE
Update vagrant nodepool provider

### DIFF
--- a/inventory/group_vars/vagrant
+++ b/inventory/group_vars/vagrant
@@ -27,12 +27,15 @@ nodepool_labels:
 nodepool_providers:
   - name: cicloud
     cloud: cicloud
-    max-servers: 10
+    max-servers: 1
     images:
       - name: ubuntu-xenial
-        min-ram: 2048
+        min-ram: 512
         diskimage: ubuntu-xenial
         private-key: /var/lib/nodepool/.ssh/id_rsa
+    networks:
+      - name: 'internal'
+        public: False
 nodepool_mysql_host: zuul.vagrant
 nodepool_gearman_servers:
   - host: zuul.vagrant


### PR DESCRIPTION
Update the nodepool provider defined in the vagrant group vars to
work with the current opentechsjc network setup. There are multiple
networks, so we must specify one to use. Also reduce the minimum nodes
to reduce resource overhead.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>