### PR TITLE
Remove the default_deny on monitoring vhost

### DIFF
--- a/inventory/group_vars/monitoring
+++ b/inventory/group_vars/monitoring
@@ -5,12 +5,7 @@ bonnyci_kibana_apache_mods_enabled:
 
 bonnyci_kibana_apache_vhosts:
   - name: default_deny
-    server_name: default.only
-    vhost_extra: |
-      <Location />
-        Order allow,deny
-        Deny from all
-      </Location>
+    delete: yes
 
   - name: kibana
     server_name: "{{ bonnyci_kibana_apache_server_name | default('elk') }}"


### PR DESCRIPTION
The default deny rule on the monitoring host is conflicting with the
letsencrypt role that is also listening on this port. It's kind of hard
to get the servername through to letsencrypt to deconflict them so just
remove the deny rule.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>