### PR TITLE
Copy zuul and nodepool logs into bonny reporter

### DIFF
--- a/.bonnyci/pull-logs.yml
+++ b/.bonnyci/pull-logs.yml
@@ -1,0 +1,30 @@
+---
+- hosts: localhost
+  become: no
+  tasks:
+    - name: create local log directories
+      file:
+        state: directory
+        path: "{{ log_dest }}{{ item }}"
+      with_items:
+        - /var/log/
+
+- hosts: nodepool
+  become: no
+  tasks:
+    - name: copy nodepool logs
+      synchronize:
+        mode: pull
+        recursive: yes
+        src: /var/log/nodepool
+        dest: "{{ log_dest }}/var/log"
+
+- hosts: zuul
+  become: no
+  tasks:
+    - name: copy zuul logs
+      synchronize:
+        mode: pull
+        recursive: yes
+        src: /var/log/zuul
+        dest: "{{ log_dest }}/var/log"

--- a/tests/test-hoist-ansible.sh
+++ b/tests/test-hoist-ansible.sh
@@ -14,6 +14,10 @@ ansible-playbook -vvvv -i inventory/nodepool.py tests/files/validate-ci.yml
 
 echo "Running hoist ansible deployment test again, and check for expected number of changes"
 ansible-playbook -i inventory/nodepool.py install-ci.yml --skip-tags monitoring,letsencrypt -e @secrets.yml.example | tee second_run.out
+
+echo "Copying logs from tests"
+ansible-playbook -i inventory/nodepool.py .bonnyci/pull-logs.yml -e "log_dest=$BONNYCI_TEST_LOG_DIR"
+
 # shellcheck disable=SC2016
 ACTUAL_CHANGE_NUMBER=$(grep "changed=" second_run.out | awk '{ print $1" "$4 }' |  sed -n -e 'H;${x;s/\n/, /g;s/^, //;p;}')
 if ! [[ "$ACTUAL_CHANGE_NUMBER" == "$EXPECTED_CHANGE_NUMBER" ]]; then


### PR DESCRIPTION
We often want to see what went wrong with a hoist job, copy the zuul and
nodepool logs for now as these are the most likely to fail.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>