### PR TITLE
Redirect all zuul web requests to the app

### DIFF
--- a/inventory/group_vars/zuul
+++ b/inventory/group_vars/zuul
@@ -1,7 +1,6 @@
 bonnyci_zuul_webapp_apache_mods_enabled:
   - proxy.load
   - proxy_http.load
-  - rewrite.load
 
 bonnyci_zuul_webapp_apache_vhosts:
   - name: status
@@ -15,10 +14,7 @@ bonnyci_zuul_webapp_apache_vhosts:
     certificate_key_file: "{{ letsencrypt_key_path | default('') }}"
     certificate_chain_file: "{{ letsencrypt_chain_path | default('') }}"
     vhost_extra: |
-      RewriteEngine on
-      RewriteRule ^/status.json$ http://127.0.0.1:8001/status.json [P]
-      RewriteRule ^/status/(.*) http://127.0.0.1:8001/status/$1 [P]
-      RewriteRule ^/connection/github/payload$ http://127.0.0.1:8001/connection/github/payload [P]
+      ProxyPass / http://127.0.0.1:8001/
 
 zuul_sites:
   bonnyci-scp:


### PR DESCRIPTION
Zuul V3 has tenant names in the URLs so they are much more variable.
This means that we can't simply rely on hardcoding a couple of paths
into our apache config and we should probably just forward everything to
the zuul app.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>