### PR TITLE
Stop directing people to https://bonnyci.org in failure messages

### DIFF
--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -38,4 +38,4 @@ zuul_zuul_v3: False
 zuul_zookeeper_hosts:
   - "127.0.0.1:2181"
 
-zuul_merge_failure_message: "Merge Failed! Help can be found at https://bonnyci.org/lore/end_users/use/#handling-merge-failures"
+zuul_merge_failure_message: "Merge Failed! Help can be found at http://bonnyci.org/lore/end_users/use/#handling-merge-failures"


### PR DESCRIPTION
We cant do ssl with github pages, so stop pointing people there.

Related-Issue: BonnyCI/projman#220

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>