### PR TITLE
Move ara-db stuff into opentech-sjc-common directory

### DIFF
--- a/inventory/group_vars/opentech-sjc-common
+++ b/inventory/group_vars/opentech-sjc-common
@@ -30,3 +30,8 @@ bonnyci_kibana_apache_server_aliases:
 bonnyci_logs_apache_server_name: logs.opentechsjc.bonnyci.org
 bonnyci_logs_apache_server_aliases:
   - logs.bonnyci.org
+
+bonnyci_ara_db_host: logs.internal.opentechsjc.bonnyci.org
+bonnyci_ara_db_clients:
+  - bastion.internal.opentechsjc.bonnyci.org
+  - logs.internal.opentechsjc.bonnyci.org

--- a/inventory/group_vars/opentech-sjc-v2
+++ b/inventory/group_vars/opentech-sjc-v2
@@ -4,10 +4,6 @@ bastion_clouds:
   - opentech-sjc
 
 bonnyci_logs_scp_host: logs.internal.opentechsjc.bonnyci.org
-bonnyci_ara_db_host: logs.internal.opentechsjc.bonnyci.org
-bonnyci_ara_db_clients: 
-  - bastion.internal.opentechsjc.bonnyci.org
-  - logs.internal.opentechsjc.bonnyci.org
 bonnyci_zuul_webapp_apache_server_name: zuul.opentechsjc.bonnyci.org
 bonnyci_zuul_merger_apache_server_name: merger01.internal.opentechsjc.bonnyci.org
 

--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -10,10 +10,6 @@ zuul_git_repo_url: https://github.com/BonnyCI/zuul
 zuul_git_branch: zuul-v3-github
 
 bonnyci_logs_scp_host: logs.internal.opentechsjc.bonnyci.org
-bonnyci_ara_db_host: logs.internal.opentechsjc.bonnyci.org
-bonnyci_ara_db_clients: 
-  - bastion.internal.opentechsjc.bonnyci.org
-  - logs.internal.opentechsjc.bonnyci.org
 bonnyci_zuul_webapp_apache_server_name: zuul.v3.opentechsjc.bonnyci.org
 bonnyci_zuul_merger_apache_server_name: merger01.internal.v3.opentechsjc.bonnyci.org
 


### PR DESCRIPTION
Both the bastion and the logs host are both deployed as part of
the opentech-sjc-common inventory.  This moves the required
ARA stuff into there and out of the zuul-specific inventories,
which dont deploy either.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>