### PR TITLE
Add bastion to opentech-sjc-common group

### DIFF
--- a/inventory/opentech-sjc-common
+++ b/inventory/opentech-sjc-common
@@ -17,6 +17,7 @@ elk.opentechsjc.bonnyci.org
 backups.opentechsjc.bonnyci.org
 
 [opentech-sjc-common]
+bastion.opentechsjc.bonnyci.org ansible_connection=local
 logs.opentechsjc.bonnyci.org
 elk.opentechsjc.bonnyci.org
 backups.opentechsjc.bonnyci.org


### PR DESCRIPTION
This is necessary for the bastion to read in the opentech-sjc-common
group_vars, which seems like the appropriate place to put settings
related to where to find the ARA database in production.

Signed-off-by: Bradon Kanyid <bradon@kanyid.org>