### PR TITLE
Fix github status links to point to https logs

### DIFF
--- a/inventory/group_vars/opentech-sjc-v2
+++ b/inventory/group_vars/opentech-sjc-v2
@@ -50,6 +50,6 @@ nodepool_zmq_publishers:
   - tcp://zuul.internal.opentechsjc.bonnyci.org:8888
 
 zuul_gearman_server: zuul.internal.opentechsjc.bonnyci.org
-zuul_logs_url: http://logs.bonnyci.org
+zuul_logs_url: https://logs.bonnyci.org
 
 dns_subdomain: internal.opentechsjc.bonnyci.org


### PR DESCRIPTION
http://logs.bonnyci.org doesn't really work anymore for serving logs,
since we moved to https. This points the status links at the https url
instead, so our users can see their logs.

Signed-off-by: Bradon Kanyid <bradon@kanyid.org>