### PR TITLE
Fix argument parsing in vagrant-deploy.sh

### DIFF
--- a/tools/vagrant-deploy.sh
+++ b/tools/vagrant-deploy.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 vagrant up
-vagrant ssh bastion -c 'sudo -i -u cideploy /vagrant/tools/vagrant-run-ansible.sh "$@"'
+vagrant ssh -c "sudo -i -u cideploy /vagrant/tools/vagrant-run-ansible.sh $*" bastion


### PR DESCRIPTION
Previously, command line arguments were not being passed correctly to
run anisble on the bastion host. Now that has been corrected.

Related-Issue: BonnyCI/projman#238
Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>