### PR TITLE
Export ARA_DATABASE in ansible-runner for ansible

### DIFF
--- a/roles/ansible-runner/templates/ansible-runner-config
+++ b/roles/ansible-runner/templates/ansible-runner-config
@@ -1,4 +1,4 @@
 ANSIBLE_PLAYBOOK={{ item.playbook }}
 ANSIBLE_INVENTORY=/opt/source/{{ item.name }}/inventory/{{ item.inventory }}
 ANSIBLE_SSH_USER={{ item.ansible_remote_user | default('') }}
-ARA_DATABASE=mysql+pymysql://{{ ara_db_username }}:{{ ara_db_password }}@{{ ara_db_host }}/ara
+export ARA_DATABASE=mysql+pymysql://{{ ara_db_username }}:{{ ara_db_password }}@{{ ara_db_host }}/ara


### PR DESCRIPTION
I thought that having ARA_DATABASE available in the ansible-runner
script would pass those env vars to the ansible process that is started
from that script. Apparently not.

This exports the var so it is in ansible's environment. It unexports
itself at the end of the script, so it doesn't linger in the caller's
shell.

Signed-off-by: Bradon Kanyid <bradon@kanyid.org>