### PR TITLE
Tidy docker-deploy.sh

### DIFF
--- a/tools/docker-deploy.sh
+++ b/tools/docker-deploy.sh
@@ -4,8 +4,8 @@ SCRIPT_NAME=$(basename "$0")
 
 print_help(){
 cat << EOF
-Usage: "$SCRIPT_NAME"
-   or: "$SCRIPT_NAME" [OPTIONS] [ANSIBLE OPTIONS]
+Usage: $SCRIPT_NAME
+   or: $SCRIPT_NAME [OPTIONS] [ANSIBLE OPTIONS]
 Deploy Docker-based development environment.
 
       --with-ansible           run ansible deploy
@@ -13,7 +13,6 @@ Deploy Docker-based development environment.
 
   -h, --help     display this help and exit
 EOF
-exit 0
 }
 
 deploy_ansible(){
@@ -42,6 +41,7 @@ main(){
         case "$arg" in
             -h|--help)
                 print_help
+                exit 0
                 ;;
             --with-ansible)
                 WITH_ANSIBLE=true


### PR DESCRIPTION
Previously, there were unnecessary quotes around `$SCRIPT_NAME` in
`print_help`. This confused the output of `--help` somewhat. Also,
having `exit 0` inside of `print_help` was less clear than it could have
been.

Now, the quotes have been removed and the exit statement has been moved
into the argument parsing block.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>