### PR TITLE
Fixup vagrant port forwards

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -115,7 +115,7 @@ Vagrant.configure(2) do |config|
   config.vm.define :logs do |logs|
     logs.vm.hostname = 'logs.vagrant'
     logs.vm.network "private_network", ip: "10.0.0.102"
-    logs.vm.network "forwarded_port", guest: 80, host: 8085
+    logs.vm.network "forwarded_port", guest: 80, host: 8082
 
     logs.vm.provider "virtualbox" do |v|
       v.memory = '512'
@@ -159,6 +159,7 @@ Vagrant.configure(2) do |config|
     elk.vm.hostname = 'elk.vagrant'
     elk.vm.network "private_network", ip: "10.0.0.104"
     elk.vm.network "forwarded_port", guest: 80, host: 8084
+    elk.vm.network "forwarded_port", guest: 5601, host: 5601
 
     elk.vm.provider "virtualbox" do |v|
       v.memory = '2048'


### PR DESCRIPTION
Match the 808X port to the .10X ip address. This was already the case
for most 808X ports, but both logs and backups were trying to use port
8085. Since backups uses ip address .105, use the port on that host. The
logs host uses ip address .102 so use port 8082 on that host.

Also add a direct port forward for kibana to bypass the apache reverse
proxy in front of it.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>