### PR TITLE
Add backup ssh key to the example secrets file

### DIFF
--- a/secrets.yml.example
+++ b/secrets.yml.example
@@ -53,6 +53,25 @@ secrets:
   zuul_github_api_key: demokey
   zuul_github_webhook_token: webhooksigner
   ssh_keys:
+    backup:
+      private: |
+        -----BEGIN RSA PRIVATE KEY-----
+        MIICXQIBAAKBgQDoitDW0TOltJtxOLZWlT6SP/5dAtsewCqvAugyOGLsNBnWCqtw
+        4LWWWKgch4ugPsLYTowEtW5mn/6e4A+OjCDB/zsunXJxxLhySRldChXWwrjnwfAv
+        hgt7KIPG35SuKXjkb4DX0NhI8qytRwz+tq9Xf5hTUKb8o5t6PS56vqiBkQIDAQAB
+        AoGATwX1aDrZgUM526T5Gb1H8S08BGGXEwEcwDKNs5tDyp799KXVkttZ+giQwHkz
+        crZBQn6WyHbbWJagUV81Ci0GaCCckpI9maGNgr6iui9gAfwO7eOh99htL7hZCxRI
+        y7SVLwFcF1D7+299cSVGLWSYjrdwrDU3AXQlxkcUO4N285ECQQD9+ix0lh4X+3ha
+        TOFfRb98cphhNcsOF/1386dLlCV0MMk5zQL9mFBsiRY44Wu6pV97/UP8SR00VpkG
+        35aNiUodAkEA6mTwYR00biLT+bOt7sSI15HL/HX7SXFkOP9C6McGmyHhIcfqm17R
+        Y+6XhLZJDYL1ivDNrDgAV6f7lTP/kH0bBQJBAJBFSHOBwt6Err085tkj2b5rqjuu
+        PwZmgkldUy8PnKb//46h8ozztNuyk7kD9Bo2TqM0HyZ0se5FMvBAmlkUH9ECQHo8
+        /eeHlYpCe43jmLfGox7ZGCqnVM9uZTgcV0aSVO2ec4xsd/tjLYwSJ868ScjUHT3C
+        a2B/LB6KqnebUJKHzAkCQQD0h1vkS3dkVnuKyKfl1l74orUFZ4IUqw+s66IOoGS1
+        WhEKnpGyv9bLDvLuQEOVzd+l5gqkfZk/qeePlTaIbvdl
+        -----END RSA PRIVATE KEY-----
+      public: >
+        ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQDoitDW0TOltJtxOLZWlT6SP/5dAtsewCqvAugyOGLsNBnWCqtw4LWWWKgch4ugPsLYTowEtW5mn/6e4A+OjCDB/zsunXJxxLhySRldChXWwrjnwfAvhgt7KIPG35SuKXjkb4DX0NhI8qytRwz+tq9Xf5hTUKb8o5t6PS56vqiBkQ== testing
     cideploy:
       private: |
         -----BEGIN RSA PRIVATE KEY-----


### PR DESCRIPTION
Re-use the testing ssh key as the backup key.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>