### PR TITLE
Update secrets file handling in vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,16 +41,17 @@ Vagrant.configure(2) do |config|
       # Install some dependencies
       /vagrant/tools/install-ansible.sh
 
-      # If there's no secrets.yml in the working directory, use the example file
-      if ! test -f /vagrant/secrets.yml ; then
-        cp /vagrant/secrets.yml.example /vagrant/secrets.yml
-      fi
-
-      # Create a symlink pointing at the live secrets.yml
-      if test -f /etc/secrets.yml ; then
+      # Remove existing secrets from bastion
+      if [[ -f /etc/secrets.yml ]]; then
         rm /etc/secrets.yml
       fi
-      cp /vagrant/secrets.yml /etc/secrets.yml
+
+      # Add secrets file to bastion
+      if [[ -f /vagrant/secrets.yml ]]; then
+        cp /vagrant/secrets.yml /etc/secrets.yml
+      else
+        cp /vagrant/secrets.yml.example /etc/secrets.yml
+      fi
 
       # disable cron runs, run ansible manually while testing
       touch /etc/disable-ansible-runner-cideploy


### PR DESCRIPTION
Previously, provisioning the bastion VM in vagrant would put what
whatever was in `secrets.yml` in place on the bastion, causing many our
local tests to be rendered inaccurate.

Now, if there is a file at `hoist/secrets.yml`, that is used, but if
there is no file there, we use `hoist/secrets.yml.example`. In effect,
we will no longer have to manually remove `hoist/secrets.yml` everytime
there is a change to the example file.

NOTE: Anyone who has an old copy of secrets.yml from before this change
will still be using that one. If you do not have a reason for using a
customized secrets file, you should remove the file at
`hoist/secrets.yml`.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>