### PR TITLE
Give each ansible-runner task its own virtualenv

### DIFF
--- a/roles/ansible-runner/tasks/ara.yml
+++ b/roles/ansible-runner/tasks/ara.yml
@@ -2,9 +2,9 @@
 - name: Install ara
   pip:
     name: "ara>=0.13.0"
-    virtualenv: "{{ ansible_runner_virtualenv }}"
+    virtualenv: "{{ venv_dir }}"
 
 - name: Install ara database driver
   pip:
     name: pymysql
-    virtualenv: "{{ ansible_runner_virtualenv }}"
+    virtualenv: "{{ venv_dir }}"

--- a/roles/ansible-runner/tasks/main.yml
+++ b/roles/ansible-runner/tasks/main.yml
@@ -12,40 +12,6 @@
     - git
     - cron
 
-- name: Install ansible
-  pip:
-    virtualenv: "{{ ansible_runner_virtualenv }}"
-    name: ansible
-
-- name: Create callback plugins path
-  file:
-    path: "{{ ansible_runner_virtualenv }}/plugins/callback"
-    state: directory
-    mode: 0755
-    owner: root
-    group: root
-
-- block:
-  - name: Install datadog callback plugin
-    get_url:
-      url: "{{ datadog_callback_url }}"
-      dest: "{{ ansible_runner_virtualenv }}/plugins/callback/datadog_callback.py"
-      mode: 0755
-      owner: root
-      group: root
-
-  - name: Install datadog callback configuration
-    copy:
-      dest: "{{ ansible_runner_virtualenv }}/plugins/callback/datadog_callback.yml"
-      content: "api_key: {{ secrets.datadog.api_key }}"
-      mode: 0644
-      owner: root
-      group: root
-
-  when: datadog_enabled | default(True) | bool
-  tags:
-    - datadog
-
 - name: Install ansible-runner
   copy:
     src: usr/local/bin/ansible-runner
@@ -70,6 +36,3 @@
 
 - include: runner.yml
   with_items: "{{ ansible_runner_tasks }}"
-
-- include: ara.yml
-  when: ara_enabled | default(False) | bool

--- a/roles/ansible-runner/tasks/runner.yml
+++ b/roles/ansible-runner/tasks/runner.yml
@@ -1,3 +1,46 @@
+- set_fact:
+    venv_dir: "/opt/venvs/{{ item.name }}"
+
+- name: Install ansible
+  pip:
+    virtualenv: "{{ venv_dir }}"
+    name: ansible
+
+- name: Create callback plugins path
+  file:
+    path: "{{ venv_dir }}/plugins/callback"
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
+
+- block:
+  - name: Install datadog callback plugin
+    get_url:
+      url: "{{ datadog_callback_url }}"
+      dest: "{{ venv_dir }}/plugins/callback/datadog_callback.py"
+      mode: 0755
+      owner: root
+      group: root
+
+  - name: Install datadog callback configuration
+    copy:
+      dest: "{{ venv_dir }}/plugins/callback/datadog_callback.yml"
+      content: "api_key: {{ secrets.datadog.api_key }}"
+      mode: 0644
+      owner: root
+      group: root
+
+  when: datadog_enabled | default(True) | bool
+  tags:
+    - datadog
+
+- name: Ensure virtualenv ownership
+  file:
+    dest: "{{ venv_dir }}"
+    owner: "{{ item.user }}"
+    recurse: yes
+
 - name: Install config file
   template:
     src: ansible-runner-config
@@ -24,7 +67,7 @@
 
 - name: Install playbook deps
   pip:
-    virtualenv: "{{ ansible_runner_virtualenv }}"
+    virtualenv: "{{ venv_dir }}"
     requirements: "/opt/source/{{ item.name }}/requirements.txt"
   when: requirements_txt.stat.exists
 
@@ -54,3 +97,6 @@
     minute: "{{ ansible_runner_minute | default(omit) }}"
     user: "{{ item.user }}"
     job: "/usr/local/bin/ansible-runner {{ item.name }} -e @{{ ansible_runner_secrets_path }}"
+
+- include: ara.yml
+  when: ara_enabled | default(False) | bool

--- a/roles/ansible-runner/templates/ansible-runner-config
+++ b/roles/ansible-runner/templates/ansible-runner-config
@@ -1,3 +1,4 @@
+ANSIBLE_RUNNER_VENV="{{ venv_dir }}"
 ANSIBLE_PLAYBOOK={{ item.playbook }}
 ANSIBLE_INVENTORY=/opt/source/{{ item.name }}/inventory/{{ item.inventory }}
 ANSIBLE_SSH_USER={{ item.ansible_remote_user | default('') }}


### PR DESCRIPTION
We currently share a base virtualenv among ansible-runner tasks, into
which we install ansible, datadog callbacks, ara and requirements for
all ansible-runners.  This is problematic because 1) ansible-runners
that do not run as root require sudo access to update the virtualenv
2) we can potentially end up with version conflicts among dependencies

Instead, this sets up isolated virtualenvs for each runner task, each with
their own callbacks, dependency set, etc.

Closes-issue: BonnyCI/projman#242

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>