### PR TITLE
Fixup the v3 tenant file

### DIFF
--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -85,11 +85,15 @@ zuul_connections:
     webhook_token: "{{ secrets.zuul_github_v3_webhook_token | default('') }}"
 
 zuul_tenants:
-  - name: BonnyV3
+  - name: BonnyCI
     source:
-      gerrithub:
+      github:
         config-projects:
-          - BonnyCI/project-config-v3
+          - BonnyCI/project-config
+        untrusted-projects:
+          - BonnyCI/requests-mock
+
+      gerrithub:
         untrusted-projects:
           - BonnyCI/sandbox-v3
 


### PR DESCRIPTION
Move the project-config over to github without the -v3 prefix. Call the
tenant BonnyCI instead of BonnyV3. We're not going to get them confused
and it's a nicer thing for a consumer.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>