### PR TITLE
Put the correct integration key in place in v3

### DIFF
--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -27,6 +27,7 @@ zuul_git_user_name: Anne Bonny
 zuul_merger_apache_port: 8858
 zuul_merger_url: "http://{{ inventory_hostname }}:{{ zuul_merger_apache_port }}/p"
 
+zuul_github_integration_key_content: ''
 zuul_github_integration_key_file: /etc/zuul/integration.key
 
 zuul_connections:
@@ -34,5 +35,5 @@ zuul_connections:
     driver: github
     api_token: "{{ secrets.zuul_github_api_key | default('') }}"
     integration_id: "{{ secrets.zuul_github_integration_id | default('') }}"
-    integration_key: "{{ secrets.zuul_github_integration_key_content | default(False) | ternary(zuul_github_integration_key_file, '') }}"
+    integration_key: "{{ zuul_github_integration_key_content | default(False) | ternary(zuul_github_integration_key_file, '') }}"
     webhook_token: "{{ secrets.zuul_github_webhook_token | default('') }}"

--- a/inventory/group_vars/opentech-sjc-v2
+++ b/inventory/group_vars/opentech-sjc-v2
@@ -49,6 +49,8 @@ nodepool_labels:
 nodepool_zmq_publishers:
   - tcp://zuul.internal.opentechsjc.bonnyci.org:8888
 
+zuul_github_integration_key_content: "{{ secrets.zuul_github_integration_key_content }}"
+
 zuul_gearman_server: zuul.internal.opentechsjc.bonnyci.org
 zuul_logs_url: https://logs.bonnyci.org
 

--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -81,8 +81,10 @@ zuul_connections:
     driver: github
     api_token: "{{ secrets.zuul_github_api_key | default('') }}"
     integration_id: "{{ secrets.zuul_github_v3_integration_id | default('') }}"
-    integration_key: "{{ secrets.zuul_github_v3_integration_key_content | default(False) | ternary(zuul_github_integration_key_file, '') }}"
+    integration_key: "{{ zuul_github_integration_key_content | default(False) | ternary(zuul_github_integration_key_file, '') }}"
     webhook_token: "{{ secrets.zuul_github_v3_webhook_token | default('') }}"
+
+zuul_github_integration_key_content: "{{ secrets.zuul_github_v3_integration_key_content }}"
 
 zuul_tenants:
   - name: BonnyCI

--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -9,6 +9,8 @@ zuul_gearman_server_start: true
 zuul_gearman_server_log_config: /etc/zuul/gearman-logging.conf
 zuul_gearman_server_listen_address: 127.0.0.1
 
+zuul_github_integration_key_content: ''
+
 zuul_logs_url: http://{{ ansible_fqdn }}
 
 zuul_statsd_enable: no

--- a/roles/zuul/tasks/main.yml
+++ b/roles/zuul/tasks/main.yml
@@ -73,11 +73,11 @@
 - name: Install zuul integration key
   copy:
     dest: /etc/zuul/integration.key
-    content: "{{ secrets.zuul_github_integration_key_content }}"
+    content: "{{ zuul_github_integration_key_content }}"
     owner: zuul
     group: zuul
     mode: 0400
-  when: secrets.zuul_github_integration_key_content | default(False)
+  when: zuul_github_integration_key_content | default(False)
 
 - name: Install zuul config
   template:


### PR DESCRIPTION
We have some level of abstraction in specifying the file for the
integration key in v2 and v3, however in both environments we were
actually still copying the v2 key. This means that v3 can't authenticate
correctly.

Fix that to put the v3 key in place in the v3 environment.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>