### PR TITLE
Index full debug logs into ELK

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -118,8 +118,7 @@
                 - zuul-launcher
                 - zuul-server
               paths:
-                - /var/log/zuul/launcher.log
-                - /var/log/zuul/server.log
+                - /var/log/zuul/*debug.log
               multiline:
                 match: after
                 negate: true
@@ -170,7 +169,7 @@
                 - zuul
                 - zuul-merger
               paths:
-                - /var/log/zuul/merger.log
+                - /var/log/zuul/*debug.log
               multiline:
                 match: after
                 negate: true
@@ -216,10 +215,7 @@
               tags:
                 - nodepool
               paths:
-                - /var/log/nodepool/nodepool-builder.log
-                - /var/log/nodepool/nodepool-deleter.log
-                - /var/log/nodepool/nodepool-launcher.log
-                - /var/log/nodepool/nodepoold.log
+                - /var/log/nodepool/*debug.log
               multiline:
                 match: after
                 negate: true


### PR DESCRIPTION
Switch logstash to listen to the debug logs rather than the
non-debug logs. They don't seem to be too large, so we should
be fine at this level until our user base grows significantly.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>