### PR TITLE
Remove bot host as it is no longer needed

### DIFF
--- a/create-cloud-resources.yml
+++ b/create-cloud-resources.yml
@@ -59,13 +59,6 @@
             - sg-common
             - sg-http-https
           key_name: "{{ deploy_ssh_key_name }}"
-        - name: bot
-          floating_ip_address: 169.44.171.92
-          flavor: m1.tiny
-          security_groups:
-            - sg-common
-            - sg-http-https
-          key_name: "{{ deploy_ssh_key_name }}"
         - name: backups
           security_groups:
             - sg-common


### PR DESCRIPTION
Sadly, we don't need quartermaster at the moment. We can keep the
playbook and roles around in case we ever want to turn it back on again.

Signed-off-by: Clint Byrum <clint@fewbar.com>