### PR TITLE
Use correct handler name

### DIFF
--- a/roles/letsencrypt-nginx/meta/main.yml
+++ b/roles/letsencrypt-nginx/meta/main.yml
@@ -19,4 +19,4 @@ dependencies:
 
   - role: letsencrypt
     letsencrypt_webroot: /etc/letsencrypt/webroot
-    letsencrypt_reload_handler: reload nginx
+    letsencrypt_reload_handler: Reload nginx


### PR DESCRIPTION
Handler names are case sensitive so must pass the proper name through to
the letsencrypt module.