### PR TITLE
Remove trusted certificate from nginx config

### DIFF
--- a/roles/nginx/templates/vhost.conf
+++ b/roles/nginx/templates/vhost.conf
@@ -21,10 +21,6 @@ server {
 
     ssl_stapling on;
     ssl_stapling_verify on;
-
-    {% if item.certificate_chain_file is defined %}
-    ssl_trusted_certificate {{ item.certificate_chain_file }};
-    {% endif %}
     {% endif %}
 
     {{ item.content | indent(4) }}


### PR DESCRIPTION
In nginx the entire certificate chain goes into the certificate file.
ssl_trusted_certificate is the CA used to verify provided client certs
and OCSP responses. We will almost never need to set that.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>