### PR TITLE
Specify ssl for secure sites

### DIFF
--- a/roles/nginx/templates/vhost.conf
+++ b/roles/nginx/templates/vhost.conf
@@ -1,10 +1,11 @@
 {% set default_port = (item.ssl | default(False) | ternary(443, 80)) -%}
+{% set use_ssl_str = (item.ssl | default(False) | ternary(' ssl', '')) -%}
 
 server {
     {% if item.listen_host | default(False) %}
-    listen {{ item.listen_host }}:{{ item.port | default(default_port) }};
+    listen {{ item.listen_host }}:{{ item.port | default(default_port) }}{{ use_ssl_str }};
     {% else %}
-    listen {{ item.port | default(default_port) }};
+    listen {{ item.port | default(default_port) }}{{ use_ssl_str }};
     {% endif %}
 
     {% if item.server_name is defined %}


### PR DESCRIPTION
The nginx equivalent of SSLEngine On is putting 'ssl' in the listen line
of the site definition.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>