### PR TITLE
Add integration-handler setup

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -104,6 +104,13 @@
         - monitoring
 
     - role: zuul
+      zuul_tenant_file: "{{ bonnyci_zuul_tenant_file | default(omit) }}"
+
+    - role: integration-handler
+      integration_handler_template_file: "{{ bonnyci_zuul_tenant_file | default(omit) }}"
+      when:
+        - zuul_zuul_v3
+        - bonnyci_use_integration
 
     - role: dd-zuul
       tags:

--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -5,6 +5,7 @@ zuul_zuul_v3: True
 
 bonnyci_use_apache: False
 bonnyci_use_nginx: True
+bonnyci_use_integration: True
 
 nodepool_git_repo_url: https://github.com/openstack-infra/nodepool
 nodepool_git_version: feature/zuulv3
@@ -71,6 +72,10 @@ nodepool_diskimages:
 
 nodepool_zmq_publishers:
   - tcp://zuul.internal.v3.opentechsjc.bonnyci.org:8888
+
+integration_handler_integration_id: "{{ secrets.zuul_github_v3_integration_id | default('') }}"
+integration_handler_integration_key: "{{ zuul_github_integration_key_content | default(False) | ternary(zuul_github_integration_key_file, '') }}"
+integration_handler_webhook_key: "{{ secrets.zuul_github_v3_webhook_token | default('') }}"
 
 zuul_gearman_server: zuul.internal.v3.opentechsjc.bonnyci.org
 zuul_logs_url: http://logs.bonnyci.org

--- a/inventory/group_vars/zuul
+++ b/inventory/group_vars/zuul
@@ -3,6 +3,9 @@ bonnyci_zuul_webapp_apache_mods_enabled:
   - proxy_http.load
   - rewrite.load
 
+integration_handler_uwsgi_socket: /var/uwsgi-sockets/integration-handler.sock
+bonnyci_zuul_tenant_file: /etc/zuul/tenant-template.yaml
+
 bonnyci_zuul_webapp_apache_vhosts:
   - name: status
     delete: true
@@ -28,21 +31,36 @@ bonnyci_zuul_webapp_nginx_sites:
     certificate_key_file: "{{ letsencrypt_key_path | default('') }}"
     certificate_chain_file: "{{ letsencrypt_chain_path | default('') }}"
     content: |
-        location /status.json {
-          proxy_pass http://127.0.0.1:8001/status.json;
-        }
+      {% if zuul_zuul_v3 %}
+      if ($http_x_github_event ~ "^installation") {
+        rewrite ^/connection/github/ /integration/ last;
+      }
 
-        location /status/ {
-          proxy_pass http://127.0.0.1:8001/status/;
-        }
+      location /connection/ {
+        proxy_pass http://127.0.0.1:8001/connection/;
+      }
 
-        location /connection/ {
-          proxy_pass http://127.0.0.1:8001/connection/;
-        }
+      location /integration/ {
+        uwsgi_pass unix://{{ integration_handler_uwsgi_socket }};
+        include uwsgi_params;
+      }
+      {% else %}
+      location /status.json {
+        proxy_pass http://127.0.0.1:8001/status.json;
+      }
 
-        location / {
-          return 404;
-        }
+      location /status/ {
+        proxy_pass http://127.0.0.1:8001/status/;
+      }
+
+      location /connection/ {
+        proxy_pass http://127.0.0.1:8001/connection/;
+      }
+      {% endif %}
+
+      location / {
+        return 404;
+      }
 
 zuul_sites:
   bonnyci-scp:

--- a/roles/integration-handler/defaults/main.yml
+++ b/roles/integration-handler/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+integration_handler_git_repo: https://github.com/BonnyCI/integration-handler.git
+integration_handler_git_version: master
+
+integration_handler_integration_id: ''
+integration_handler_integration_key: ''
+integration_handler_output_file: ''
+integration_handler_webhook_key: ''
+integration_handler_template_file: /etc/zuul/tenant-template.yaml
+
+integration_handler_zuul_tenant_file: /etc/zuul/tenant.yaml
+integration_handler_zuul_tenant_mode: "0644"
+integration_handler_zuul_user: zuul
+
+integration_handler_uwsgi_user: "{{ integration_handler_zuul_user }}"
+integration_handler_uwsgi_socket: /var/uwsgi-sockets/integration-handler.sock

--- a/roles/integration-handler/handlers/main.yml
+++ b/roles/integration-handler/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Reload integration-handler uwsgi
+  file:
+    path: /etc/uwsgi-emperor/vassals/integration-handler.ini
+    state: touch
+
+- name: Run integration-handler
+  command: "{{ integration_handler_venv_path }}/bin/bonnyci-integration-handler-run"
+  environment: "{{ integration_handler_env }}"

--- a/roles/integration-handler/meta/main.yml
+++ b/roles/integration-handler/meta/main.yml
@@ -1,0 +1,24 @@
+---
+dependencies:
+  - role: python-app
+    name: integration-handler
+    python_app_git_repo: "{{ integration_handler_git_repo }}"
+    python_app_git_version: "{{ integration_handler_git_version }}"
+    python_app_notify: Reload integration-handler uwsgi
+
+  - role: uwsgi
+    uwsgi_apt_plugins:
+      - uwsgi-plugin-python
+    uwsgi_vassals:
+      - name: integration-handler
+        state: present
+        config:
+          uid: "{{ integration_handler_zuul_user }}"
+          gid: www-data
+          wsgi-file: "{{ integration_handler_venv_path }}/bin/bonnyci-integration-handler-wsgi"
+          virtualenv: "{{ integration_handler_venv_path }}"
+          plugin: python
+          socket: "{{ integration_handler_uwsgi_socket }}"
+          lazy-apps: true
+
+        env: "{{ integration_handler_env }}"

--- a/roles/integration-handler/tasks/main.yml
+++ b/roles/integration-handler/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: create invoke script
+  template:
+    src: invoke.sh.j2
+    dest: "{{ integration_handler_invoke_path }}"
+    mode: 0755
+    owner: root
+
+- name: create sudoers file
+  template:
+    src: etc/sudoers.d/90-bonnyci-integration-handler
+    dest: /etc/sudoers.d/90-bonnyci-integration-handler
+    mode: 0440
+    owner: root
+    validate: 'visudo -cf %s'
+
+- name: Trigger run if tenant file doesn't exist
+  stat:
+    path: "{{ integration_handler_zuul_tenant_file }}"
+  register: integration_handler_tenant_stat
+  changed_when: not integration_handler_tenant_stat.stat.exists
+  notify: Run integration-handler

--- a/roles/integration-handler/templates/etc/sudoers.d/90-bonnyci-integration-handler
+++ b/roles/integration-handler/templates/etc/sudoers.d/90-bonnyci-integration-handler
@@ -1,0 +1,1 @@
+{{ integration_handler_uwsgi_user }} ALL=(ALL) NOPASSWD: {{ integration_handler_invoke_path }}

--- a/roles/integration-handler/templates/invoke.sh.j2
+++ b/roles/integration-handler/templates/invoke.sh.j2
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cp $1 {{ integration_handler_zuul_tenant_file }}
+chown {{ integration_handler_zuul_user }}: {{ integration_handler_zuul_tenant_file }}
+chmod {{ integration_handler_zuul_tenant_mode }} {{ integration_handler_zuul_tenant_file }}
+systemctl reload zuul-scheduler

--- a/roles/integration-handler/vars/main.yml
+++ b/roles/integration-handler/vars/main.yml
@@ -1,0 +1,10 @@
+integration_handler_invoke_path: /usr/local/bin/bonnyci-integration-invoke.sh
+integration_handler_invoke: "sudo {{ integration_handler_invoke_path }}"
+
+integration_handler_env:
+  BIH_INTEGRATION_ID: "{{ integration_handler_integration_id }}"
+  BIH_INTEGRATION_KEY: "{{ integration_handler_integration_key }}"
+  BIH_INVOKE: "{{ integration_handler_invoke }}"
+  BIH_OUTPUT_FILE: "{{ integration_handler_output_file }}"
+  BIH_WEBHOOK_KEY: "{{ integration_handler_webhook_key }}"
+  BIH_TEMPLATE: "{{ integration_handler_template_file }}"

--- a/roles/uwsgi/tasks/main.yml
+++ b/roles/uwsgi/tasks/main.yml
@@ -6,6 +6,14 @@
   with_items:
     - uwsgi-emperor
 
+- name: Setup sockets directory
+  file:
+    path: /var/uwsgi-sockets
+    owner: www-data
+    group: www-data
+    mode: "0775"
+    state: directory
+
 - name: Install apt plugins
   apt:
     name: "{{ item }}"

--- a/roles/uwsgi/templates/vassal.ini
+++ b/roles/uwsgi/templates/vassal.ini
@@ -3,3 +3,7 @@
 {% for key, value in item.config.items() -%}
 {{ key }} = {{ value }}
 {% endfor %}
+
+{% for key, value in (item.env | default({})).items() -%}
+env = {{ key }}={{value}}
+{% endfor %}

--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -18,6 +18,7 @@ zuul_statsd_host: 127.0.0.1
 zuul_statsd_port: 8125
 
 zuul_tenants: []
+zuul_tenant_file: /etc/zuul/tenant.yaml
 
 zuul_webapp_listen_address: 127.0.0.1
 zuul_webapp_port: 8001

--- a/roles/zuul/tasks/scheduler.yml
+++ b/roles/zuul/tasks/scheduler.yml
@@ -8,10 +8,11 @@
     - scheduler
   notify: Restart zuul
 
+# FIXME: need to figure out some way of notify/running integration-handler here
 - name: Install tenant.yaml
   template:
     src: etc/zuul/tenant.yaml
-    dest: /etc/zuul/tenant.yaml
+    dest: "{{ zuul_tenant_file }}"
     owner: zuul
   notify: Reload zuul-server
 


### PR DESCRIPTION
The integration-handler will handle webhooks specific to how we actually
setup our integration. Things like when a new installation was created
and we want to add that to our tenant file. Nginx will look at the event
type header and redirect certain events off to the handler.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>