### PR TITLE
Don't use /etc/letsencrypt as the webroot

### DIFF
--- a/roles/letsencrypt-nginx/meta/main.yml
+++ b/roles/letsencrypt-nginx/meta/main.yml
@@ -3,7 +3,6 @@ dependencies:
     nginx_sites:
       - name: letsencrypt
         state: present
-        document_root: /etc/letsencrypt/webroot
         port: 80
         content: |
           location /.well-known/acme-challenge {
@@ -18,5 +17,4 @@ dependencies:
           {% endif %}
 
   - role: letsencrypt
-    letsencrypt_webroot: /etc/letsencrypt/webroot
     letsencrypt_reload_handler: Reload nginx


### PR DESCRIPTION
The letsencrypt-nginx role is setting the ansible handler to use the
/etc/letsencrypt/webroot dir as the challenge folder and the nginx path
to be /var/www/letsencrypt.

It feels more correct to serve it out of /var/www so remove the /etc
handling.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>