### PR TITLE
Fix nginx letsencrypt directory

### DIFF
--- a/roles/letsencrypt-nginx/meta/main.yml
+++ b/roles/letsencrypt-nginx/meta/main.yml
@@ -7,7 +7,7 @@ dependencies:
         content: |
           location /.well-known/acme-challenge {
             allow all;
-            root {{ letsencrypt_webroot }}/.well-known/acme-challenge;
+            root {{ letsencrypt_webroot }};
           }
 
           {% if letsencrypt_configure_redirect %}

--- a/roles/letsencrypt/defaults/main.yml
+++ b/roles/letsencrypt/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-letsencrypt_webroot: /var/www/html/letsencrypt
+letsencrypt_webroot: /var/www/letsencrypt
 
 letsencrypt_production: no
 letsencrypt_acme_directory: "{{ letsencrypt_production | ternary(letsencrypt_production_api, letsencrypt_staging_api) }}"


### PR DESCRIPTION
We need to specify only the root directory, not the full path for nginx
or the well-known part is appended twice.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>