### PR TITLE
Don't add requests-mock to zuul v3 deploy

### DIFF
--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -102,8 +102,6 @@ zuul_tenants:
       github:
         config-projects:
           - BonnyCI/project-config
-        untrusted-projects:
-          - BonnyCI/requests-mock
 
       gerrithub:
         untrusted-projects:


### PR DESCRIPTION
In the zuul v3 deployment we have the integration handler that will
discover the projects that it should test. This will pick up
requests-mock if appropriate so we don't need to include it in the list
any more.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>