### PR TITLE
Add bubblewrap to zuul executor

### DIFF
--- a/roles/zuul/tasks/executor.yml
+++ b/roles/zuul/tasks/executor.yml
@@ -1,3 +1,16 @@
+- name: Add bubblewrap PPA
+  apt_repository:
+    repo: "ppa:openstack-ci-core/bubblewrap"
+    state: present
+    update_cache: yes
+
+- name: Install bubblewrap
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - bubblewrap
+
 - name: Install zuul-executor logging config
   template:
     src: "etc/zuul/logging.conf"

--- a/roles/zuul/templates/etc/zuul/zuul_v3.conf
+++ b/roles/zuul/templates/etc/zuul/zuul_v3.conf
@@ -30,6 +30,7 @@ zookeeper_hosts = {{ zuul_zookeeper_hosts | join(",") }}
 
 [executor]
 log_config = /etc/zuul/executor-logging.conf
+untrusted_wrapper = bubblewrap
 
 [launcher]
 workspace_root=/home/bonnyci/workspace


### PR DESCRIPTION
Install the PPA and packages required to run bubblewrap in our zuul v3
deployment.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>