### PR TITLE
Set executor finger port to something high

### DIFF
--- a/inventory/group_vars/zuul
+++ b/inventory/group_vars/zuul
@@ -67,3 +67,5 @@ zuul_sites:
     host: "{{ bonnyci_logs_scp_host }}"
     user: "{{ bonnyci_logs_scp_user }}"
     root: "{{ bonnyci_logs_root_dir }}"
+
+zuul_executor_finger_port: 9099

--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -2,6 +2,9 @@ zuul_git_repo_url: https://github.com/BonnyCI/zuul
 zuul_git_branch: github-integration
 zuul_allow_restart_services: no
 
+zuul_executor_untrusted_wrapper: bubblewrap
+zuul_executor_finger_port: 79
+
 zuul_gearman_server: 127.0.0.1
 zuul_gearman_port: 4730
 

--- a/roles/zuul/templates/etc/zuul/zuul_v3.conf
+++ b/roles/zuul/templates/etc/zuul/zuul_v3.conf
@@ -30,7 +30,8 @@ zookeeper_hosts = {{ zuul_zookeeper_hosts | join(",") }}
 
 [executor]
 log_config = /etc/zuul/executor-logging.conf
-untrusted_wrapper = bubblewrap
+untrusted_wrapper = {{ zuul_executor_untrusted_wrapper }}
+finger_port = {{ zuul_executor_finger_port }}
 
 [launcher]
 workspace_root=/home/bonnyci/workspace


### PR DESCRIPTION
I don't really care what the executor finger port is, it just needs to
be outside of the priviledged space so that we can run the executor
without root.