### PR TITLE
Forward everything through nginx to zuul in v3

### DIFF
--- a/inventory/group_vars/zuul
+++ b/inventory/group_vars/zuul
@@ -36,13 +36,13 @@ bonnyci_zuul_webapp_nginx_sites:
         rewrite ^/connection/github/ /integration/ last;
       }
 
-      location /connection/ {
-        proxy_pass http://127.0.0.1:8001/connection/;
-      }
-
       location /integration/ {
         uwsgi_pass unix://{{ integration_handler_uwsgi_socket }};
         include uwsgi_params;
+      }
+
+      location / {
+        proxy_pass http://127.0.0.1:8001/;
       }
       {% else %}
       location /status.json {
@@ -56,11 +56,11 @@ bonnyci_zuul_webapp_nginx_sites:
       location /connection/ {
         proxy_pass http://127.0.0.1:8001/connection/;
       }
-      {% endif %}
 
       location / {
         return 404;
       }
+      {% endif %}
 
 zuul_sites:
   bonnyci-scp:


### PR DESCRIPTION
In zuul v3 we have tenant based status.json files and secret keys that
are exposed via the webapp. To access these from outside we need to
export them through nginx.

We can't know all this ahead of time so just forward everything through
nginx to zuul.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>