### PR TITLE
Fixup nginx SSL

### DIFF
--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -13,8 +13,6 @@ nodepool_git_version: feature/zuulv3
 zuul_git_repo_url: https://github.com/BonnyCI/zuul
 zuul_git_branch: zuul-v3-github
 
-letsencrypt_cert_path: /etc/letsencrypt/cert/ansible.combined.crt
-
 bonnyci_logs_scp_host: logs.internal.opentechsjc.bonnyci.org
 bonnyci_zuul_webapp_server_name: zuul.v3.opentechsjc.bonnyci.org
 bonnyci_zuul_merger_server_name: merger01.internal.v3.opentechsjc.bonnyci.org

--- a/inventory/group_vars/zuul
+++ b/inventory/group_vars/zuul
@@ -27,9 +27,8 @@ bonnyci_zuul_webapp_nginx_sites:
   - name: webapp
     server_name: "{{ bonnyci_zuul_webapp_server_name | default('zuul') }}"
     ssl: "{{ bonnyci_zuul_webapp_ssl | default(False) }}"
-    certificate_file: "{{ letsencrypt_cert_path | default('') }}"
+    certificate_file: "{{ letsencrypt_combined_path | default('') }}"
     certificate_key_file: "{{ letsencrypt_key_path | default('') }}"
-    certificate_chain_file: "{{ letsencrypt_chain_path | default('') }}"
     content: |
       {% if zuul_zuul_v3 %}
       if ($http_x_github_event ~ "^installation") {


### PR DESCRIPTION
The letsencrypt task will concat the letsencrypt cert with the chain
cert to make a file that nginx can use. Unfortunately because we were
overriding the letsencrypt cert path to be the combined file this file
was growing longer and longer as it was concatenated with itself. This
would cause SSL connections to receive an invalid chain and fail.

Clean this up so that the single certificate file and combined file are
properly seperate.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>