### PR TITLE
Small fixups to zuul with python3

### DIFF
--- a/roles/zuul/meta/main.yml
+++ b/roles/zuul/meta/main.yml
@@ -1,7 +1,7 @@
 dependencies:
   - role: python-app
     name: zuul
-    python_app_python_version: "{% if zuul_zuul_v3 %}3{% endif %}"
+    python_app_python_version: "{{ zuul_python_version }}"
     python_app_pipdeps:
       - name: pyzmq
       - name: ansible

--- a/roles/zuul/tasks/main.yml
+++ b/roles/zuul/tasks/main.yml
@@ -88,7 +88,6 @@
 
 - name: Install datadog logging library
   pip:
-    executable: "pip{{ zuul_python_version }}"
     name: git+https://github.com/BonnyCI/datadog-logging.git#egg=datadog-logging
     state: latest
     virtualenv: "{{ zuul_venv_path }}"


### PR DESCRIPTION
I don't think this is a complete fix, but use the zuul_python_version
variable consistently as it's there. Also you can't specify executable
and virtualenv together to pip. You specify the virtualenv and it will
figure out which python is installed in there.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>