### PR TITLE
Don't specify python_app_version is "2"

### DIFF
--- a/roles/zuul/vars/v2.yml
+++ b/roles/zuul/vars/v2.yml
@@ -1,2 +1,2 @@
 zuul_conf_template_src: etc/zuul/zuul_v2.conf
-zuul_python_version: "2"
+zuul_python_version: ""


### PR DESCRIPTION
The python app version is being used directly in package names, but
things like python2-dev don't exist. For python 2 it should simply be
unset.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>