### PR TITLE
Default to python3 for zuul 3

### DIFF
--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -16,8 +16,6 @@ zuul_github_integration_key_content: ''
 
 zuul_logs_url: http://{{ ansible_fqdn }}
 
-zuul_python_version: "2"
-
 zuul_statsd_enable: no
 zuul_statsd_host: 127.0.0.1
 zuul_statsd_port: 8125
@@ -42,6 +40,7 @@ zuul_sites: {}
 zuul_url_pattern: "{{ zuul_logs_url }}/{build.parameters[LOG_PATH]}"
 
 zuul_zuul_v3: False
+zuul_python_version: "{% if zuul_zuul_v3 %}3{% endif %}"
 
 zuul_zookeeper_hosts:
   - "127.0.0.1:2181"

--- a/roles/zuul/vars/v2.yml
+++ b/roles/zuul/vars/v2.yml
@@ -1,2 +1,1 @@
 zuul_conf_template_src: etc/zuul/zuul_v2.conf
-zuul_python_version: ""

--- a/roles/zuul/vars/v3.yml
+++ b/roles/zuul/vars/v3.yml
@@ -1,2 +1,1 @@
 zuul_conf_template_src: etc/zuul/zuul_v3.conf
-zuul_python_version: "3"


### PR DESCRIPTION
Setting python_version in vars/vX.yml is too late. These get included in
tasks and so are not present until after meta has run so they are not
actually being picked up.

We could set this in our deployment, but just change the default so that
v3 uses python3 by default.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>