### PR TITLE
Specify combined path in group_vars

### DIFF
--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -10,6 +10,7 @@ filebeat_output_logstash_enabled: true
 
 letsencrypt_account_key_content: "{{ secrets.letsencrypt.account_key }}"
 letsencrypt_cert_path: /etc/letsencrypt/cert/ansible.crt
+letsencrypt_combined_path: /etc/letsencrypt/cert/ansible.combined.crt
 letsencrypt_chain_path: /etc/letsencrypt/chain.pem
 letsencrypt_csr_dn:
   C: AU


### PR DESCRIPTION
We really should be depending on variables from one task to another. It
means we have to specify them all in the top level group_vars file like
this and that they are not really reusable.

However for speed given they are already here just add the missing
filename.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>