### PR TITLE
Rename github integration to app

### DIFF
--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -31,13 +31,13 @@ zuul_git_user_name: Anne Bonny
 zuul_merger_apache_port: 8858
 zuul_merger_url: "http://{{ inventory_hostname }}:{{ zuul_merger_apache_port }}/p"
 
-zuul_github_integration_key_content: ''
-zuul_github_integration_key_file: /etc/zuul/integration.key
+zuul_github_app_key_content: ''
+zuul_github_app_key_file: /etc/zuul/app.key
 
 zuul_connections:
   github:
     driver: github
     api_token: "{{ secrets.zuul_github_api_key | default('') }}"
-    integration_id: "{{ secrets.zuul_github_integration_id | default('') }}"
-    integration_key: "{{ zuul_github_integration_key_content | default(False) | ternary(zuul_github_integration_key_file, '') }}"
+    app_id: "{{ secrets.zuul_github_app_id | default('') }}"
+    app_key: "{{ zuul_github_app_key_content | default(False) | ternary(zuul_github_app_key_file, '') }}"
     webhook_token: "{{ secrets.zuul_github_webhook_token | default('') }}"

--- a/inventory/group_vars/opentech-sjc-v2
+++ b/inventory/group_vars/opentech-sjc-v2
@@ -49,7 +49,7 @@ nodepool_labels:
 nodepool_zmq_publishers:
   - tcp://zuul.internal.opentechsjc.bonnyci.org:8888
 
-zuul_github_integration_key_content: "{{ secrets.zuul_github_integration_key_content }}"
+zuul_github_app_key_content: "{{ secrets.zuul_github_app_key_content }}"
 
 zuul_gearman_server: zuul.internal.opentechsjc.bonnyci.org
 zuul_logs_url: https://logs.bonnyci.org

--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -5,7 +5,7 @@ zuul_zuul_v3: True
 
 bonnyci_use_apache: False
 bonnyci_use_nginx: True
-bonnyci_use_integration: True
+bonnyci_use_app: True
 
 nodepool_git_repo_url: https://github.com/openstack-infra/nodepool
 nodepool_git_version: feature/zuulv3
@@ -71,8 +71,8 @@ nodepool_diskimages:
 nodepool_zmq_publishers:
   - tcp://zuul.internal.v3.opentechsjc.bonnyci.org:8888
 
-integration_handler_integration_id: "{{ secrets.zuul_github_v3_integration_id | default('') }}"
-integration_handler_integration_key: "{{ zuul_github_integration_key_content | default(False) | ternary(zuul_github_integration_key_file, '') }}"
+integration_handler_integration_id: "{{ secrets.zuul_github_v3_app_id | default('') }}"
+integration_handler_integration_key: "{{ zuul_github_app_key_content | default(False) | ternary(zuul_github_app_key_file, '') }}"
 integration_handler_webhook_key: "{{ secrets.zuul_github_v3_webhook_token | default('') }}"
 
 zuul_gearman_server: zuul.internal.v3.opentechsjc.bonnyci.org
@@ -88,11 +88,11 @@ zuul_connections:
   github:
     driver: github
     api_token: "{{ secrets.zuul_github_api_key | default('') }}"
-    integration_id: "{{ secrets.zuul_github_v3_integration_id | default('') }}"
-    integration_key: "{{ zuul_github_integration_key_content | default(False) | ternary(zuul_github_integration_key_file, '') }}"
+    app_id: "{{ secrets.zuul_github_v3_app_id | default('') }}"
+    app_key: "{{ zuul_github_app_key_content | default(False) | ternary(zuul_github_app_key_file, '') }}"
     webhook_token: "{{ secrets.zuul_github_v3_webhook_token | default('') }}"
 
-zuul_github_integration_key_content: "{{ secrets.zuul_github_v3_integration_key_content }}"
+zuul_github_app_key_content: "{{ secrets.zuul_github_v3_app_key_content }}"
 
 zuul_tenants:
   - name: BonnyCI

--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -12,7 +12,7 @@ zuul_gearman_server_start: true
 zuul_gearman_server_log_config: /etc/zuul/gearman-logging.conf
 zuul_gearman_server_listen_address: 127.0.0.1
 
-zuul_github_integration_key_content: ''
+zuul_github_app_key_content: ''
 
 zuul_logs_url: http://{{ ansible_fqdn }}
 


### PR DESCRIPTION
With the public release of the integration github changed the name to
app. In turn we updated the github driver in zuul to use the word app
instead. Fix hoist to use these terms.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>