### PR TITLE
Don't need to install python packages in bastion role

### DIFF
--- a/roles/bastion/tasks/main.yml
+++ b/roles/bastion/tasks/main.yml
@@ -103,15 +103,6 @@
     state: absent
   notify: restart sshd
 
-- name: install required ubuntu packages
-  apt:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - libffi-dev
-    - libssl-dev
-    - python-dev
-
 - name: install required python packages
   pip:
     name: "{{ item }}"


### PR DESCRIPTION
The python-app role will install the python dependencies that are
required so we don't need to do this manually.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>