### PR TITLE
Add sshd role to lockdown ssh

### DIFF
--- a/bastion.yml
+++ b/bastion.yml
@@ -12,6 +12,10 @@
     - role: common
       common_hostname: "{{ bonnyci_hostname | default('') }}"
 
+    - role: sshd
+      tags:
+        - sshd
+
     - role: dd-agent
       tags:
         - monitoring

--- a/install-ci.yml
+++ b/install-ci.yml
@@ -10,6 +10,10 @@
     - role: common
       common_hostname: "{{ bonnyci_hostname | default('') }}"
 
+    - role: sshd
+      tags:
+        - sshd
+
     - role: dd-agent
       tags:
         - monitoring

--- a/roles/sshd/defaults/main.yml
+++ b/roles/sshd/defaults/main.yml
@@ -1,0 +1,7 @@
+sshd_listen_addresses: []
+sshd_port: 22
+sshd_permit_root_login: no
+sshd_password_authentication: no
+sshd_x11_forwarding: no
+sshd_use_pam: yes
+sshd_challenge_response_authentication: no

--- a/roles/sshd/handlers/main.yml
+++ b/roles/sshd/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: Restart sshd
+  service:
+    name: ssh
+    state: restarted

--- a/roles/sshd/tasks/main.yml
+++ b/roles/sshd/tasks/main.yml
@@ -1,0 +1,20 @@
+- name: Install SSHD
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - openssh-server
+
+- name: setup sshd config
+  template:
+    src: etc/ssh/sshd_config
+    dest: /etc/ssh/sshd_config
+    owner: root
+    mode: "0644"
+  notify: Restart sshd
+
+- name: ensure ssh started
+  service:
+    name: ssh
+    state: started
+    enabled: yes

--- a/roles/sshd/templates/etc/ssh/sshd_config
+++ b/roles/sshd/templates/etc/ssh/sshd_config
@@ -1,0 +1,94 @@
+# {{ ansible_managed }}
+
+# What ports, IPs and protocols we listen for
+Port {{ sshd_port }}
+
+# Use these options to restrict which interfaces/protocols sshd will bind to
+#ListenAddress ::
+#ListenAddress 0.0.0.0
+{% for add in sshd_listen_addresses %}
+ListenAddress {{ add }}
+{% endfor %}
+
+Protocol 2
+
+# HostKeys for protocol version 2
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_dsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
+
+#Privilege Separation is turned on for security
+UsePrivilegeSeparation yes
+
+# Lifetime and size of ephemeral version 1 server key
+KeyRegenerationInterval 3600
+ServerKeyBits 1024
+
+# Logging
+SyslogFacility AUTH
+LogLevel INFO
+
+# Authentication:
+LoginGraceTime 120
+PermitRootLogin {{ sshd_permit_root_login | ternary("yes", "no") }}
+StrictModes yes
+
+RSAAuthentication yes
+PubkeyAuthentication yes
+#AuthorizedKeysFile	%h/.ssh/authorized_keys
+
+# Don't read the user's ~/.rhosts and ~/.shosts files
+IgnoreRhosts yes
+# For this to work you will also need host keys in /etc/ssh_known_hosts
+RhostsRSAAuthentication no
+# similar for protocol version 2
+HostbasedAuthentication no
+# Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication
+#IgnoreUserKnownHosts yes
+
+# To enable empty passwords, change to yes (NOT RECOMMENDED)
+PermitEmptyPasswords no
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+ChallengeResponseAuthentication {{ sshd_challenge_response_authentication | ternary("yes", "no") }}
+
+# Change to no to disable tunnelled clear text passwords
+PasswordAuthentication {{ sshd_password_authentication | ternary("yes", "no") }}
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosGetAFSToken no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+
+X11Forwarding {{ sshd_x11_forwarding | ternary("yes", "no") }}
+X11DisplayOffset 10
+PrintMotd no
+PrintLastLog yes
+TCPKeepAlive yes
+#UseLogin no
+
+#MaxStartups 10:30:60
+#Banner /etc/issue.net
+
+# Allow client to pass locale environment variables
+AcceptEnv LANG LC_*
+
+Subsystem sftp /usr/lib/openssh/sftp-server
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+UsePAM {{ sshd_use_pam | ternary("yes", "no") }}


### PR DESCRIPTION
With the change to softlayer we end up having ssh root login enabled by
default. Create an sshd role that will lock down SSH root access and
some other security tweaks.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>