### PR TITLE
Use system account with datadog-builder

### DIFF
--- a/roles/datadog-builder/tasks/datadog-builder.yml
+++ b/roles/datadog-builder/tasks/datadog-builder.yml
@@ -25,6 +25,7 @@
     group: datadog-builder
     home: /var/lib/datadog-builder
     state: present
+    system: yes
 
 - name: Create log file
   file:


### PR DESCRIPTION
Small tweak, but we should really be creating a system user for the
datadog-builder account.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>