### PR TITLE
Start moving BonnyCI over to softlayer

### DIFF
--- a/inventory/host_vars/bastion.opentech.bonnyci.org
+++ b/inventory/host_vars/bastion.opentech.bonnyci.org
@@ -1,0 +1,8 @@
+ansible_runner_tasks:
+    - name: system-ansible
+      playbook: bastion.yml
+      inventory: opentech-sl-bastion
+      repo: http://github.com/BonnyCI/hoist.git
+      user: root
+
+bonnyci_bastion_ssl: false

--- a/inventory/opentech-sl-bastion
+++ b/inventory/opentech-sl-bastion
@@ -1,0 +1,2 @@
+[bastion]
+bastion.opentech.bonnyci.org ansible_connection=local


### PR DESCRIPTION
For various political reasons we have to move the control plane of the
cloud over to SoftLayer. Set up the most basic inventory bits to get the
bastion working.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>