### PR TITLE
Don't install shade to root on bastion

### DIFF
--- a/roles/bastion/tasks/main.yml
+++ b/roles/bastion/tasks/main.yml
@@ -103,13 +103,6 @@
     state: absent
   notify: restart sshd
 
-- name: install required python packages
-  pip:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - shade
-
 - name: create jump scripts
   template:
     src: usr/local/bin/jump


### PR DESCRIPTION
I'm not entirely sure what this was from, however let's never install
anything from pip into the root. That way lies pain.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>