### PR TITLE
Set OFFLINE_NODE_WHEN_COMPLETE for Zuul v2.5 jobs

### DIFF
--- a/roles/zuul/files/etc/zuul/config/bonnyci_functions.py
+++ b/roles/zuul/files/etc/zuul/config/bonnyci_functions.py
@@ -13,8 +13,15 @@ def set_log_path(item, job, params):
     params['LOG_PATH'] = '%s/%s' % (params['BASE_LOG_PATH'], job.name)
 
 
+def set_offline_node_after_use(item, job, params):
+    # This ensures nodes are taken offline and not re-used after a
+    # test has run on them.
+    params['OFFLINE_NODE_WHEN_COMPLETE'] = 1
+
+
 FUNCS = [
     set_log_path,
+    set_offline_node_after_use,
 ]
 
 


### PR DESCRIPTION
A rac eexists between Zuul v2.5 + nodepool where Zuul will start
new jobs on dirty nodes before nodepool can clean them up.  Set
the OFFLINE_NODE_WHEN_COMPLETE parameter on all jobs to avoid
this.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>