### PR TITLE
Hacky scripts to get softlayer working

### DIFF
--- a/install-python.yml
+++ b/install-python.yml
@@ -1,0 +1,10 @@
+# python isn't installed by default on ubuntu cloud images any more which is a
+# problem for ansible. For us this is most notable that it's not present in the
+# softlayer images and we don't really have the ability to spin up our own.
+---
+- hosts: all
+  gather_facts: False
+  become: yes
+  tasks:
+    - name: install python 2 if it's not available (ubuntu)
+      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)

--- a/setup-softlayer.yml
+++ b/setup-softlayer.yml
@@ -1,0 +1,24 @@
+# Softlayer machines come with SSH root access and no users set up. This doesn't
+# match how OpenStack and other providers work so create a user with the right
+# ssh key so we don't nee to modify our whole hoist repo to handle softlayer.
+---
+- hosts: all
+  vars:
+    softlayer_user: ubuntu
+    softlayer_authorized_key: "{{ secrets.ssh_keys.cideploy.public | mandatory }}"
+  tasks:
+    - name: create a group
+      group:
+        name: "{{ softlayer_user }}"
+
+    - name: create a user
+      user:
+        name: "{{ softlayer_user }}"
+        group: "{{ softlayer_user }}"
+        state: present
+
+    - name: add cideploy authorized key
+      authorized_key:
+        user: "{{ softlayer_user }}"
+        exclusive: yes
+        key: "{{ softlayer_authorized_key }}"


### PR DESCRIPTION
Two scripts to get softlayer boxes to the point where we can actually
use them.

Install python on the image. Newer ubuntu images don't come with python
preinstalled which causes a lot of problems for ansible. We worked
around this in OpenStack by uploading our own images that have python
installed but softlayer makes that more difficult.

Softlayer gives you access to a root account on the boxes which we don't
really want and have an openssh rule to lock down. Add a script to
create a user with the right ssh keys so we can trigger ansible runs.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>