### PR TITLE
Enable SSL on opentech

### DIFF
--- a/inventory/host_vars/elk.opentech.bonnyci.org
+++ b/inventory/host_vars/elk.opentech.bonnyci.org
@@ -2,5 +2,5 @@
 ansible_host: elk.internal.opentech.bonnyci.org
 ansible_user: ubuntu
 
-bonnyci_elk_ssl: no
-letsencrypt_csr_cn: elk.bonnyci.org
+bonnyci_elk_ssl: yes
+letsencrypt_csr_cn: elk.opentech.bonnyci.org

--- a/inventory/host_vars/logs.opentech.bonnyci.org
+++ b/inventory/host_vars/logs.opentech.bonnyci.org
@@ -2,5 +2,5 @@
 ansible_host: logs.internal.opentech.bonnyci.org
 ansible_user: ubuntu
 
-bonnyci_logs_ssl: no
-letsencrypt_csr_cn: logs.bonnyci.org
+bonnyci_logs_ssl: yes
+letsencrypt_csr_cn: logs.opentech.bonnyci.org


### PR DESCRIPTION
This is more difficult than expected. I thought that saying no to ssl
prevented letsencrypt from going at all. For now enable SSL but include
the opentech part in the domain name.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>