### PR TITLE
Put mysql on bastion for ARA

### DIFF
--- a/bastion.yml
+++ b/bastion.yml
@@ -44,13 +44,22 @@
             - notifempty
       when: secrets is defined
 
+    - role: mysql
+      mysql_root_password: "{{ secrets.db_password }}"
+      tags: ['mysql']
+
+    - role: dd-mysql
+      dd_mysql_password: "{{ secrets.datadog.mysql_password }}"
+      tags:
+        - monitoring
+
     - role: ansible-runner
       ansible_runner_minute: "*/15"
       ansible_runner_virtualenv: /opt/ansible
       ara_enabled: "{{ bonnyci_ara_enabled | default(False) | bool }}"
       ara_db_username: "{{ secrets.ara.username }}"
       ara_db_password: "{{ secrets.ara.password }}"
-      ara_db_host: "{{ bonnyci_ara_db_host | default(omit) }}"
+      ara_db_host: "localhost"
       when: secrets is defined
 
     - role: tailon

--- a/install-ci.yml
+++ b/install-ci.yml
@@ -79,10 +79,13 @@
   tags: ['mysql']
   roles:
     - role: mysql
+      mysql_root_password: "{{ secrets.db_password }}"
+
     - role: dd-mysql
       dd_mysql_password: "{{ secrets.datadog.mysql_password }}"
       tags:
         - monitoring
+
     - role: databases
 
 - name: Install zookeeper

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -10,7 +10,9 @@
    failed_when: "apt_cache.cache_updated != True"
 
  - name: Install the MySQL packages
-   apt: name={{ item }} state=installed
+   apt:
+     name: "{{ item }}"
+     state: installed
    with_items:
      - mysql-server
      - mysql-client
@@ -32,7 +34,11 @@
      enabled: true
 
  - name: Update MySQL root password for all root accounts
-   mysql_user: name=root host={{ item }} password={{ secrets.db_password }} state=present
+   mysql_user:
+     name: root
+     host: "{{ item }}"
+     password: "{{ mysql_root_password }}"
+     state: present
    with_items:
      - "{{ ansible_hostname }}"
      - 127.0.0.1
@@ -46,7 +52,10 @@
      mode: 0600
 
  - name: Ensure Anonymous user(s) are not in the database
-   mysql_user: name='' host={{ item }} state=absent
+   mysql_user:
+     name: ''
+     host: "{{ item }}"
+     state: absent
    with_items:
      - localhost
      - "{{ ansible_hostname }}"


### PR DESCRIPTION
Nodepool doesn't have a mysql database for v3 so it's a bit difficult to deploy
ARA in new environments for this. Add a mysql to bastion for ARA.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>