### PR TITLE
Fixup the ARA deployment scripts to match others

### DIFF
--- a/bastion.yml
+++ b/bastion.yml
@@ -53,6 +53,35 @@
       tags:
         - monitoring
 
+    - role: ara-db
+      ara_db_username: "{{ secrets.ara.username }}"
+      ara_db_password: "{{ secrets.ara.password }}"
+
+    - role: ara-web
+      ara_db_username: "{{ secrets.ara.username }}"
+      ara_db_password: "{{ secrets.ara.password }}"
+      ara_webroot: /var/www/ara
+      ara_file_owner: www-data
+      ara_file_group: www-data
+      env:
+        ANSIBLE_CONFIG: /var/www/ara/ansible.cfg
+
+    - role: uwsgi
+      uwsgi_apt_plugins:
+        - uwsgi-plugin-python
+      uwsgi_vassals:
+        - name: ara
+          state: present
+          config:
+            uid: www-data
+            gid: www-data
+            wsgi-file: "{{ ara_venv_path }}/ara-wsgi"
+            virtualenv: "{{ ara_venv_path }}"
+            chdir: /var/www/ara
+            plugin: python
+            socket: localhost:3311
+            lazy-apps: true
+
     - role: ansible-runner
       ansible_runner_minute: "*/15"
       ansible_runner_virtualenv: /opt/ansible
@@ -70,10 +99,13 @@
         - "/var/www/html/cron-logs/**/*_current.log"
 
     - role: apache
+      apache_apt_install:
+        - libapache2-mod-proxy-uwsgi
       apache_mods_enabled:
         - proxy.conf
         - proxy.load
         - proxy_http.load
+        - proxy_uwsgi.load
       apache_vhosts:
         - name: bastion
           document_root: /var/www/html/
@@ -88,8 +120,13 @@
             Redirect permanent /cron-logs/live /cron-logs/live/
 
             ProxyPass "/cron-logs/live/" http://localhost:8080/cron-logs/live/
+
+            Redirect permanent /ara /ara/
+            ProxyPass "/ara/" uwsgi://localhost:3311/
+
         - name: tailon
           delete: yes
+
         - name: ara
           delete: yes
 

--- a/install-ci.yml
+++ b/install-ci.yml
@@ -292,15 +292,6 @@
   become: yes
   tags: ['logs']
   roles:
-    - role: ara-db
-      ara_db_username: "{{ secrets.ara.username }}"
-      ara_db_password: "{{ secrets.ara.password }}"
-    - role: ara-web
-      ara_venv_path: /opt/ara
-      ara_db_username: "{{ secrets.ara.username }}"
-      ara_db_password: "{{ secrets.ara.password }}"
-      ara_db_host: "{{ bonnyci_ara_db_host }}"
-
     - role: scp-log-receiver
       scp_log_receiver_user: "{{ bonnyci_logs_scp_user }}"
       scp_log_receiver_path:  "{{ bonnyci_logs_root_dir }}/logs"
@@ -323,16 +314,6 @@
             virtualenv: "{{ os_loganalyze_venv_path }}"
             plugin: python
             socket: localhost:3310
-            lazy-apps: true
-        - name: ara
-          state: present
-          config:
-            uid: www-data
-            gid: www-data
-            wsgi-file: "/var/www/ara/ara-wsgi"
-            virtualenv: /opt/ara
-            plugin: python
-            socket: localhost:3311
             lazy-apps: true
 
     - role: apache

--- a/roles/ara-db/meta/main.yml
+++ b/roles/ara-db/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - role: mysql

--- a/roles/ara-web/defaults/main.yml
+++ b/roles/ara-web/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+ara_webroot: /var/www/ara
+ara_file_owner: www-data
+ara_file_group: www-data

--- a/roles/ara-web/meta/main.yml
+++ b/roles/ara-web/meta/main.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+  - role: python-app
+    name: ara
+    python_app_pipdeps:
+      - name: "ara>=0.13.0"
+      - name: pymysql

--- a/roles/ara-web/tasks/main.yml
+++ b/roles/ara-web/tasks/main.yml
@@ -1,62 +1,34 @@
 ---
-- name: Install deps
-  apt:
-    name: "{{ item }}"
-    state: installed
-    update_cache: yes
-  with_items:
-    - gcc
-    - libffi-dev
-    - python-dev
-    - libssl-dev
-
-- name: Install ara
-  pip:
-    name: "ara>=0.13.0"
-    virtualenv: "{{ ara_venv_path }}"
-
-- name: Install database dependencies
-  pip:
-    name: pymysql
-    virtualenv: "{{ ara_venv_path }}"
-
 - name: Ensure ara directories
   file:
-    path: "/var/www/{{ item }}"
+    path: "{{ item }}"
     state: directory
     mode: 0755
-    owner: www-data
-    group: www-data
+    owner: "{{ ara_file_owner }}"
+    group: "{{ ara_file_group }}"
   with_items:
-    - ara
-    - ara/.ansible
+    - "{{ ara_webroot }}"
+    - "{{ ara_webroot }}/.ansible"
 
 - name: Ensure ara database directory is world-writable
   file:
-    path: "/var/www/ara/.ara"
+    path: "{{ ara_webroot }}/.ara"
     state: directory
     mode: 0777
-    owner: www-data
-    group: www-data
-
-- name: Copy ARA wsgi script into place
-  copy:
-    src: "{{ ara_venv_path }}/bin/ara-wsgi"
-    dest: /var/www/ara/
-    remote_src: True
-
+    owner: "{{ ara_file_owner }}"
+    group: "{{ ara_file_group }}"
 
 - name: Install ARA configuration
   template:
     src: var/www/ara/ansible.cfg
-    dest: /var/www/ara/ansible.cfg
+    dest: "{{ ara_webroot }}/ansible.cfg"
     mode: 0600
-    owner: www-data
-    group: www-data
+    owner: "{{ ara_file_owner }}"
+    group: "{{ ara_file_group }}"
 
 - name: Make sure apache can read everything
   file:
-    path: /var/www/ara
-    owner: www-data
-    group: www-data
+    path: "{{ ara_webroot }}"
+    owner: "{{ ara_file_owner }}"
+    group: "{{ ara_file_group }}"
     recurse: yes

--- a/roles/ara-web/templates/var/www/ara/ansible.cfg
+++ b/roles/ara-web/templates/var/www/ara/ansible.cfg
@@ -1,7 +1,7 @@
 [defaults]
 # This directory is required to store temporary files for Ansible and ARA
-local_tmp = /var/www/ara/.ansible/tmp
+local_tmp = {{ ara_webroot }}/.ansible/tmp
 
 [ara]
 database = "mysql+pymysql://{{ ara_db_username }}:{{ ara_db_password }}@{{ ara_db_host }}/ara"
-dir = /var/www/ara/.ara
+dir = {{ ara_webroot }}/.ara


### PR DESCRIPTION
Bring ARA web deployment more into line with the way everything else is
deployed and move it over to the bastion. This makes us use python-app
and correctly set the uwsgi values instead of Apache values.

I can see how this was confusing to someone who hadn't done python
deployments before.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>