### PR TITLE
Add dd-apache to the bastion that serves logs

### DIFF
--- a/bastion.yml
+++ b/bastion.yml
@@ -130,6 +130,10 @@
         - name: ara
           delete: yes
 
+    - role: dd-apache
+      tags:
+        - monitoring
+
     - role: filebeat
       filebeat_prospectors:
         - name: apache


### PR DESCRIPTION
If we're running apache on the bastion for serving cron logs and similar
we should also run dd-apache to monitor it.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>