### PR TITLE
Restart apache when apt plugins change

### DIFF
--- a/roles/apache/tasks/apache.yml
+++ b/roles/apache/tasks/apache.yml
@@ -12,6 +12,7 @@
     name: "{{ item }}"
     state: present
   with_items: "{{ apache_apt_install }}"
+  notify: restart apache
 
 - name: enable apache mods
   file:


### PR DESCRIPTION
This is fairly rare, but if you install additional apache plugins you
probably reference them in vhosts, but if not then restart apache to
handle it anyway.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>