### PR TITLE
Add /bin/ to ara venv path

### DIFF
--- a/bastion.yml
+++ b/bastion.yml
@@ -75,7 +75,7 @@
           config:
             uid: www-data
             gid: www-data
-            wsgi-file: "{{ ara_venv_path }}/ara-wsgi"
+            wsgi-file: "{{ ara_venv_path }}/bin/ara-wsgi"
             virtualenv: "{{ ara_venv_path }}"
             chdir: /var/www/ara
             plugin: python


### PR DESCRIPTION
Oops, forgot to add the /bin/ part to the path when specifying the uwsgi
executable.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>