### PR TITLE
Define ANSIBLE_CONFIG correctly for ARA

### DIFF
--- a/bastion.yml
+++ b/bastion.yml
@@ -63,8 +63,6 @@
       ara_webroot: /var/www/ara
       ara_file_owner: www-data
       ara_file_group: www-data
-      env:
-        ANSIBLE_CONFIG: /var/www/ara/ansible.cfg
 
     - role: uwsgi
       uwsgi_apt_plugins:
@@ -81,6 +79,8 @@
             plugin: python
             socket: localhost:3311
             lazy-apps: true
+          env:
+            ANSIBLE_CONFIG: /var/www/ara/ansible.cfg
 
     - role: ansible-runner
       ansible_runner_minute: "*/15"


### PR DESCRIPTION
Move the env field correctly to the uwsgi definition. We need to define
ANSIBLE_CONFIG for the app to start and I had incorrectly added the
definition to the ara-web section.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>