### PR TITLE
Set ara-web db host to localhost

### DIFF
--- a/bastion.yml
+++ b/bastion.yml
@@ -60,6 +60,7 @@
     - role: ara-web
       ara_db_username: "{{ secrets.ara.username }}"
       ara_db_password: "{{ secrets.ara.password }}"
+      ara_db_host: localhost
       ara_webroot: /var/www/ara
       ara_file_owner: www-data
       ara_file_group: www-data


### PR DESCRIPTION
The default database url should probably be localhost, but it's the
empty string. Set to localhost manually.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>