### PR TITLE
Add datadog environ tags

### DIFF
--- a/inventory/group_vars/opentech-sjc-common
+++ b/inventory/group_vars/opentech-sjc-common
@@ -32,3 +32,6 @@ bonnyci_logs_apache_server_aliases:
   - logs.bonnyci.org
 
 bonnyci_ara_db_host: logs.internal.opentechsjc.bonnyci.org
+
+datadog_tags:
+  - "environ:opentechsjc"

--- a/inventory/group_vars/opentech-sjc-v2
+++ b/inventory/group_vars/opentech-sjc-v2
@@ -52,3 +52,6 @@ zuul_gearman_server: zuul.internal.opentechsjc.bonnyci.org
 zuul_logs_url: https://logs.bonnyci.org
 
 dns_subdomain: internal.opentechsjc.bonnyci.org
+
+datadog_tags:
+  - "environ:opentechsjc"

--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -1,5 +1,8 @@
 environment_name: opentech-sjc-v3
 
+datadog_tags:
+  - "environ:opentechsjc"
+
 nodepool_zuul_v3: True
 zuul_zuul_v3: True
 

--- a/inventory/group_vars/opentech-sl
+++ b/inventory/group_vars/opentech-sl
@@ -8,6 +8,9 @@ bonnyci_use_apache: False
 bonnyci_use_nginx: True
 bonnyci_use_app: True
 
+datadog_tags:
+  - "environ:opentech"
+
 nodepool_git_repo_url: https://github.com/openstack-infra/nodepool
 nodepool_git_version: feature/zuulv3
 


### PR DESCRIPTION
Was looking into datadog and the host map is getting difficult to read.
Add the environ tag to all our environments to split it up.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>