### PR TITLE
Rename integration variable to app

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -117,7 +117,7 @@
       integration_handler_template_file: "{{ bonnyci_zuul_tenant_file | default(omit) }}"
       when:
         - zuul_zuul_v3
-        - bonnyci_use_integration
+        - bonnyci_use_app
 
     - role: dd-zuul
       tags:


### PR DESCRIPTION
This looks like a leftover from our old setup. Use the newer
bonnyci_use_app variable that was renamed after github renamed
integrations to apps.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>