### PR TITLE
Don't set zmq variables in opentech-sjc-v3

### DIFF
--- a/inventory/group_vars/opentech-sjc-v3
+++ b/inventory/group_vars/opentech-sjc-v3
@@ -71,9 +71,6 @@ nodepool_diskimages:
       DIB_NODEPOOL_SCRIPT_DIR: /etc/nodepool/scripts
       DIB_PYTHON_VERSION: '2'
 
-nodepool_zmq_publishers:
-  - tcp://zuul.internal.v3.opentechsjc.bonnyci.org:8888
-
 integration_handler_integration_id: "{{ secrets.zuul_github_v3_app_id | default('') }}"
 integration_handler_integration_key: "{{ zuul_github_app_key_content | default(False) | ternary(zuul_github_app_key_file, '') }}"
 integration_handler_webhook_key: "{{ secrets.zuul_github_v3_webhook_token | default('') }}"


### PR DESCRIPTION
Zuul v3 doesn't use zmq any more and so the variables in the v3 file are
not being used. This doesn't matter really, but it made it more
confusing when creating the opentech-sl environment and so we should
probably remove them.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>