### PR TITLE
Include bastion in production and opentech-sl

### DIFF
--- a/inventory/host_vars/bastion.opentech.bonnyci.org
+++ b/inventory/host_vars/bastion.opentech.bonnyci.org
@@ -14,4 +14,3 @@ ansible_runner_tasks:
 
 bonnyci_bastion_ssl: true
 letsencrypt_csr_cn: bastion.opentech.bonnyci.org
-dns_subdomain: internal.opentech.bonnyci.org

--- a/inventory/opentech-sl-bastion
+++ b/inventory/opentech-sl-bastion
@@ -1,2 +1,8 @@
 [bastion]
 bastion.opentech.bonnyci.org ansible_connection=local
+
+[production]
+bastion.opentech.bonnyci.org
+
+[opentech-sl]
+bastion.opentech.bonnyci.org


### PR DESCRIPTION
There are a couple of variables like letsencrypt_production that get
inheritted from these group_vars. The bastion should be a part of those
groups.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>