### PR TITLE
Use app instead of integration

### DIFF
--- a/roles/zuul/tasks/main.yml
+++ b/roles/zuul/tasks/main.yml
@@ -70,14 +70,14 @@
     group: zuul
   when: zuul_ssh_known_hosts is defined
 
-- name: Install zuul integration key
+- name: Install zuul app key
   copy:
-    dest: /etc/zuul/integration.key
-    content: "{{ zuul_github_integration_key_content }}"
+    dest: /etc/zuul/app.key
+    content: "{{ zuul_github_app_key_content }}"
     owner: zuul
     group: zuul
     mode: 0400
-  when: zuul_github_integration_key_content | default(False)
+  when: zuul_github_app_key_content | default(False)
 
 - name: Install zuul config
   template:


### PR DESCRIPTION
Another spot where we didn't correctly replace integration with app. Use
the correct variable otherwise /etc/zuul/app.key is not created.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>