### PR TITLE
Make python-app use python3 boolean instead of string

### DIFF
--- a/roles/pip/defaults/main.yml
+++ b/roles/pip/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 pip_cache_dir: /var/cache/pip-installer
 pip_install_url: https://bootstrap.pypa.io/get-pip.py
-pip_python_version: ""
+pip_python3: false

--- a/roles/pip/tasks/main.yml
+++ b/roles/pip/tasks/main.yml
@@ -11,7 +11,7 @@
     dest: "{{ pip_cache_dir }}/get-pip.py"
 
 - name: Run get-pip.py to intall Pip
-  command: "python{{ pip_python_version }} {{ pip_cache_dir }}/get-pip.py"
+  command: "{{ pip_python_exec }} {{ pip_cache_dir }}/get-pip.py"
   register: pip_command
   changed_when: "'Requirement already up-to-date: pip' not in pip_command.stdout"
 

--- a/roles/pip/vars/main.yml
+++ b/roles/pip/vars/main.yml
@@ -1,0 +1,2 @@
+---
+pip_python_exec: "{{ pip_python3 | bool | ternary('python3', 'python') }}"

--- a/roles/python-app/defaults/main.yml
+++ b/roles/python-app/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
-python_app_python_version: ""
 python_app_venv_path: /opt/venvs
 python_app_source_path: /opt/source
+python_app_python3: false
 
 python_app_git_repo: ""
 python_app_pipdeps: []

--- a/roles/python-app/meta/main.yml
+++ b/roles/python-app/meta/main.yml
@@ -1,4 +1,4 @@
 ---
 dependencies:
   - name: pip
-    pip_python_version: "{{ python_app_python_version }}"
+    pip_python3: "{{ python_app_python3 | bool }}"

--- a/roles/python-app/tasks/main.yml
+++ b/roles/python-app/tasks/main.yml
@@ -16,14 +16,14 @@
     - git
     - libffi-dev
     - libssl-dev
-    - python{{ python_app_python_version }}-dev
+    - "{{ python_app_python_exec }}-dev"
 
 - name: Install pip dependencies
   pip:
     name: "{{ item.name }}"
     version: "{{ item.version | default(omit) }}"
     virtualenv: "{{ python_app_venv_path }}/{{ name }}"
-    virtualenv_python: "python{{ python_app_python_version }}"
+    virtualenv_python: "{{ python_app_python_exec }}"
     state: "{{ item.state | default(omit) }}"
   with_items: "{{ python_app_pipdeps }}"
   when: item.when | default(True)
@@ -49,7 +49,7 @@
         extra_args: -U
         name: "{{ python_app_source_path }}/{{ name }}"
         virtualenv: "{{ python_app_venv_path }}/{{ name }}"
-        virtualenv_python: "python{{ python_app_python_version }}"
+        virtualenv_python: "{{ python_app_python_exec }}"
       when: python_app_git_checkout.changed
 
     - name: Set python-app source facts

--- a/roles/python-app/vars/main.yml
+++ b/roles/python-app/vars/main.yml
@@ -1,0 +1,2 @@
+---
+python_app_python_exec: "{{ python_app_python3 | bool | ternary('python3', 'python') }}"

--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -40,7 +40,6 @@ zuul_sites: {}
 zuul_url_pattern: "{{ zuul_logs_url }}/{build.parameters[LOG_PATH]}"
 
 zuul_zuul_v3: False
-zuul_python_version: "{% if zuul_zuul_v3 %}3{% endif %}"
 
 zuul_zookeeper_hosts:
   - "127.0.0.1:2181"

--- a/roles/zuul/meta/main.yml
+++ b/roles/zuul/meta/main.yml
@@ -1,7 +1,7 @@
 dependencies:
   - role: python-app
     name: zuul
-    python_app_python_version: "{{ zuul_python_version }}"
+    python_app_python3: "{{ zuul_zuul_v3 | bool }}"
     python_app_pipdeps:
       - name: pyzmq
       - name: ansible


### PR DESCRIPTION
Specifying a "3" string or nothing to python-app is kind of messy.
Replace it with a strict boolean that will choose either python2 or
python3 and default zuulv3 to using python3.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>