### PR TITLE
Move flush_handlers out of conditional file

### DIFF
--- a/roles/nodepool/tasks/main.yml
+++ b/roles/nodepool/tasks/main.yml
@@ -129,3 +129,27 @@
 
 - include: nodepool_v3.yml
   when: nodepool_zuul_v3 | bool
+
+- meta: flush_handlers
+
+- name: Enable and start systemd service
+  when: not (nodepool_zuul_v3 | bool)
+  service:
+    enabled: yes
+    state: started
+    service: "{{ item }}"
+  with_items:
+    - nodepool-builder
+    - nodepool-deleter
+    - nodepool-launcher
+    - nodepoold
+
+- name: Enable and start systemd service
+  when: nodepool_zuul_v3 | bool
+  service:
+    enabled: yes
+    state: started
+    service: "{{ item }}"
+  with_items:
+    - nodepool-builder
+    - nodepool-launcher

--- a/roles/nodepool/tasks/nodepool_v2.yml
+++ b/roles/nodepool/tasks/nodepool_v2.yml
@@ -27,16 +27,3 @@
   notify:
     - Reload systemd units
     - Restart nodepool
-
-- meta: flush_handlers
-
-- name: Enable and start systemd service
-  service:
-    enabled: yes
-    state: started
-    service: "{{ item }}"
-  with_items:
-    - nodepool-builder
-    - nodepool-deleter
-    - nodepool-launcher
-    - nodepoold

--- a/roles/nodepool/tasks/nodepool_v3.yml
+++ b/roles/nodepool/tasks/nodepool_v3.yml
@@ -23,14 +23,3 @@
   notify:
     - Reload systemd units
     - Restart nodepool
-
-- meta: flush_handlers
-
-- name: Enable and start systemd service
-  service:
-    enabled: yes
-    state: started
-    service: "{{ item }}"
-  with_items:
-    - nodepool-builder
-    - nodepool-launcher


### PR DESCRIPTION
When you have a meta: flush_handlers command it doesn't respect when:
conditions. That means in v3 it'll flush handlers vefore the v3 file has
actually installed them and so will fail. It should succeed on second
run but this is still wrong.

Combine things a bit so flush_handlers is run in the right spot.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>