### PR TITLE
Restart nodepool-launcher when clouds.yaml changes

### DIFF
--- a/roles/nodepool/handlers/main.yml
+++ b/roles/nodepool/handlers/main.yml
@@ -22,6 +22,11 @@
     - nodepool-builder
     - nodepool-launcher
 
+- name: Restart nodepool launcher
+  service:
+    name: nodepool-launcher
+    state: restarted
+
 - name: Restart nodepool builder
   service:
     name: nodepool-builder

--- a/roles/nodepool/tasks/main.yml
+++ b/roles/nodepool/tasks/main.yml
@@ -78,6 +78,8 @@
     owner: nodepool
     group: nodepool
     mode: 0600
+  notify:
+    - Restart nodepool launcher
 
 - name: install nodepool sudoers file (for DIB builds)
   copy:


### PR DESCRIPTION
If clouds.yaml changes it's not automatically picked up by nodepool.
Restart the launcher if it changes so we push to the right projects.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>