### PR TITLE
Use dedicated nodepool-sl network in opentech env

### DIFF
--- a/inventory/group_vars/opentech-sl
+++ b/inventory/group_vars/opentech-sl
@@ -36,7 +36,7 @@ nodepool_providers:
       - name: main
         max-servers: 2
         networks:
-          - nodepool
+          - nodepool-sl
         labels:
           - name: ubuntu-xenial
             min-ram: 1026


### PR DESCRIPTION
Don't reuse the shared network. We don't share internal IPs when dealing
with opentech so there's no point using the shared network and we should
use a project internal network.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>