### PR TITLE
Fix tenant template for zuul

### DIFF
--- a/inventory/group_vars/opentech-sl
+++ b/inventory/group_vars/opentech-sl
@@ -91,6 +91,17 @@ zuul_connections:
 
 zuul_github_app_key_content: "{{ secrets.zuul_github_v3_app_key_content }}"
 
+zuul_tenants:
+  - name: BonnyCI
+    source:
+      github:
+        config-projects:
+          - BonnyCI/project-config
+
+      gerrithub:
+        untrusted-projects:
+          - BonnyCI/sandbox-v3
+
 zuul_zookeeper_hosts:
   - nodepool.internal.opentech.bonnyci.org:2181
 


### PR DESCRIPTION
The tenant template is used as the base for projects from github that we
follow. We need to point it at the project-config by default.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>