### PR TITLE
Use config-drive on nodepool images in opentech

### DIFF
--- a/inventory/group_vars/opentech-sl
+++ b/inventory/group_vars/opentech-sl
@@ -32,6 +32,7 @@ nodepool_providers:
     cloud: opentech-sl
     diskimages:
       - name: ubuntu-xenial
+        config-drive: true
     pools:
       - name: main
         max-servers: 2


### PR DESCRIPTION
We should be using config-drive for some metadata, particularly as we're
already using glean. Enable it for now in opentech-sl as the others seem
to be working ok and this will be our real environment.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>