### PR TITLE
Use with_items to install logging

### DIFF
--- a/roles/zuul/tasks/web.yml
+++ b/roles/zuul/tasks/web.yml
@@ -2,6 +2,8 @@
 - name: Install zuul-web logging configs
   template:
     src: "etc/zuul/logging.conf"
-    dest: "/etc/zuul/web-logging.conf"
+    dest: "/etc/zuul/{{ item }}.conf"
     owner: zuul
   notify: Restart zuul-web
+  with_items:
+    - web


### PR DESCRIPTION
The logging template expects to be called in a with_items loop even if
there is only 1 element. This is a bit dodgy, but just do it for now.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>