### PR TITLE
Use full name to web logging config file

### DIFF
--- a/roles/zuul/tasks/web.yml
+++ b/roles/zuul/tasks/web.yml
@@ -2,7 +2,7 @@
 - name: Install zuul-web logging configs
   template:
     src: "etc/zuul/logging.conf"
-    dest: "/etc/zuul/{{ item }}.conf"
+    dest: "/etc/zuul/{{ item }}-logging.conf"
     owner: zuul
   notify: Restart zuul-web
   with_items:


### PR DESCRIPTION
Use the proper name for the logging config file to read. Without it zuul
fails to load the config file and zuul-web won't start.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>