### PR TITLE
Remove users from create-cloud-resources

### DIFF
--- a/create-cloud-resources.yml
+++ b/create-cloud-resources.yml
@@ -8,36 +8,15 @@
       default_ssh_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDSpmsWVIxgSe3yUBSmuDRgMZbK/vmzxMxhaMwD7vy3/voGUvx9ozxJNonY2TKF4eyWP9t2I+HFnVgSn+4LjC2t2UlUWbHB01uVtkz5avwzUaHMYuEHh25jFOoy8/mxrop11WMZleW1Hn1txRZl68H22n6IuTySKSY1HgjHyHlP3seKwZHIMAuIg1MN5LYGlyLvJ8Ew7r0B5sU/vQs6kCUnnV2NsevtaSH1k9UPLfvO8HN7pYrY057eBLEQ9r51wj2O9nL8wvso5nXWHIhuEJiZL+573Jy9PabTMt+QaQ9t2ISedyUX/dVR3H8SKmjOkvxNjmuVyMnFkotjlqEOOTGLCDsuSlg22NbF5aXuHe12ucCcwE8I/UXecZMkSfrnhoBi3y6MFcQxgwlK06V6bTOOy9LITjvMVD7COlzITSYF/y6nhkeGKGsQ8jRfWyyXoZACNwGX3DYSSZC/X3CDcJIuhJab3jfcYap/ue2GEX2p/6MN+NbZknHTX0KZU4qNf2UVnLBH8GWbcFYqG1WwERk5ClzYIvCjn2JY21Ztqvig4vQ0NKwAIBjgOk01C5c63MTRFdBAybE8AjzCr9Zp6ADcsHXRIB9olEHfSdIKCE5ynYutw9yTO7zTpRYA2gOBNlapUFxux2DNauSeNaCkA328UU94CKYr8Rh4mDM4z4seEw== cideploy@bonnyci
       image_uuid: f4611a28-112d-4383-ad3c-b8792572c5f0
       users:
-        - username: adam_g
-          email: adam.gandelman@ibm.com
-          isadmin: True
         - username: clint
           email: cbyrum@us.ibm.com
           isadmin: True
         - username: jamielennox
           email: jlennox@au1.ibm.com
           isadmin: True
-        - username: jesusaur
-          email: jonathan.harker@ibm.com
-          isadmin: True
         - username: jkeating
           email: omgjlk@us.ibm.com
           isadmin: True
-        - username: jtclark
-          email: jtclark@linux.vnet.ibm.com
-          isadmin: False
-        - username: mctaylor
-          email: mctaylor@us.ibm.com
-          isadmin: False
-        - username: mlangbehn
-          email: mlangbe@us.ibm.com
-          isadmin: False
-        - username: olaph
-          email: mwagone@us.ibm.com
-          isadmin: False
-        - username: rattboi
-          email: bradon.kanyid@ibm.com
-          isadmin: False
       common_servers:
         - name: bastion
           floating_ip_address: 169.44.171.83


### PR DESCRIPTION
Remove people who have moved on from the project from
create-cloud-resources. This file isn't automatically run, and it won't
actually remove the users/projects from the cloud, however it will
prevent them being recreated in future if it is run.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>