### PR TITLE
Only install the github app key on zuul scheduler

### DIFF
--- a/roles/zuul/tasks/main.yml
+++ b/roles/zuul/tasks/main.yml
@@ -70,15 +70,6 @@
     group: zuul
   when: zuul_ssh_known_hosts is defined
 
-- name: Install zuul app key
-  copy:
-    dest: /etc/zuul/app.key
-    content: "{{ zuul_github_app_key_content }}"
-    owner: zuul
-    group: zuul
-    mode: 0400
-  when: zuul_github_app_key_content | default(False)
-
 - name: Install zuul config
   template:
     src:  "{{ zuul_conf_template_src }}"

--- a/roles/zuul/tasks/scheduler.yml
+++ b/roles/zuul/tasks/scheduler.yml
@@ -8,6 +8,15 @@
     - scheduler
   notify: Restart zuul
 
+- name: Install zuul app key
+  copy:
+    dest: /etc/zuul/app.key
+    content: "{{ zuul_github_app_key_content }}"
+    owner: zuul
+    group: zuul
+    mode: 0400
+  when: zuul_github_app_key_content | default(False)
+
 # FIXME: need to figure out some way of notify/running integration-handler here
 - name: Install tenant.yaml
   template:


### PR DESCRIPTION
When looking into splitting up the zuul components onto different
machines we don't need to install the github app keys everywhere. The
app key should only be present on the scheduler.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>