### PR TITLE
Use dedicated zuul executor

### DIFF
--- a/inventory/group_vars/opentech-sl-zuul-executors
+++ b/inventory/group_vars/opentech-sl-zuul-executors
@@ -1,0 +1,5 @@
+---
+ansible_user: ubuntu
+
+zuul_components:
+  - zuul-executor

--- a/inventory/host_vars/zuul.opentech.bonnyci.org
+++ b/inventory/host_vars/zuul.opentech.bonnyci.org
@@ -6,7 +6,6 @@ letsencrypt_csr_cn: zuul.opentech.bonnyci.org
 bonnyci_zuul_webapp_ssl: yes
 
 zuul_components:
-  - zuul-executor
   - zuul-merger
   - zuul-scheduler
   - zuul-web

--- a/inventory/opentech-sl
+++ b/inventory/opentech-sl
@@ -24,3 +24,9 @@ nodepool.opentech.bonnyci.org
 
 [zuul]
 zuul.opentech.bonnyci.org
+
+[opentech-sl-zuul-exectuors]
+ze01.internal.opentech.bonnyci.org
+
+[zuul:children]
+opentech-sl-zuul-exectuors


### PR DESCRIPTION
I really don't like the idea of having the executor and scheduler on the
same host. Bubblewrap is giving us some protection there but if a user
escapes the sandbox it'd be nice to not give them access to everything.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>