### PR TITLE
Quick fix for executor only environment

### DIFF
--- a/inventory/opentech-sl
+++ b/inventory/opentech-sl
@@ -9,12 +9,14 @@ elk.opentech.bonnyci.org
 logs.opentech.bonnyci.org
 nodepool.opentech.bonnyci.org
 zuul.opentech.bonnyci.org
+ze01.internal.opentech.bonnyci.org
 
 [production]
 elk.opentech.bonnyci.org
 logs.opentech.bonnyci.org
 nodepool.opentech.bonnyci.org
 zuul.opentech.bonnyci.org
+ze01.internal.opentech.bonnyci.org
 
 [nodepool]
 nodepool.opentech.bonnyci.org


### PR DESCRIPTION
The executor was not in the opentech-sl group and therefore missed out
on some variables. Make sure it's in production and opentech-sl.

There are bigger problems such as installing apache and other things on
the executor nodes that is wrong, but fix the immediate problem first.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>