### PR TITLE
Add connections to zuul-executor

### DIFF
--- a/roles/zuul-executor/templates/etc/zuul/zuul.conf
+++ b/roles/zuul-executor/templates/etc/zuul/zuul.conf
@@ -4,6 +4,16 @@
 port = {{ zuul_gearman_port }}
 server = {{ zuul_gearman_server }}
 
+{% for name, details in zuul_connections.items() %}
+[connection {{ name }}]
+{% for key, value in details.items() %}
+{% if value %}
+{{ key }} = {{ value }}
+{% endif %}
+{% endfor %}
+
+{% endfor %}
+
 [executor]
 default_username = {{ zuul_executor_default_username }}
 disk_limit_per_job = {{ zuul_executor_disk_limit_per_job }}


### PR DESCRIPTION
Makes sense that the zuul-executor would need access to the connections.
Make sure they are in that template.

We probably need a way to standardize this across roles - not sure how
ansible handles that.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>