### PR TITLE
Correctly differentiate tenant file and template file

### DIFF
--- a/install-ci.yml
+++ b/install-ci.yml
@@ -205,7 +205,8 @@
       zuul_tenant_file: "{{ bonnyci_zuul_tenant_file | default(omit) }}"
 
     - role: integration-handler
-      integration_handler_template_file: "{{ bonnyci_zuul_tenant_file | default(omit) }}"
+      integration_handler_tenant_file: "{{ bonnyci_zuul_tenant_file | default(omit) }}"
+      integration_handler_template_file: "{{ bonnyci_zuul_tenant_template_file | default(omit) }}"
       when:
         - bonnyci_use_app
 

--- a/inventory/group_vars/zuul-scheduler
+++ b/inventory/group_vars/zuul-scheduler
@@ -4,7 +4,8 @@ bonnyci_zuul_webapp_apache_mods_enabled:
   - rewrite.load
 
 integration_handler_uwsgi_socket: /var/uwsgi-sockets/integration-handler.sock
-bonnyci_zuul_tenant_file: /etc/zuul/tenant-template.yaml
+bonnyci_zuul_tenant_file: /etc/zuul/tenant.yaml
+bonnyci_zuul_tenant_template_file: /etc/zuul/tenant-template.yaml
 
 bonnyci_zuul_webapp_apache_vhosts:
   - name: status


### PR DESCRIPTION
The zuul config file is pointing to the tenant-template file which means
it's not detecting projects that are registered with the integration. We
need to correctly point zuul to the output of the integration-handler.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>