### PR TITLE
Fix another zuul-server reference

### DIFF
--- a/roles/zuul-scheduler/handlers/main.yml
+++ b/roles/zuul-scheduler/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Reload zuul-server
+- name: Reload zuul-scheduler
   service:
-    name: zuul-server
+    name: zuul-scheduler
     state: reloaded


### PR DESCRIPTION
Fix another place where zuul-scheduler references the zuul-server
service. This service doesn't exist in v3.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>