### PR TITLE
Add a zuul-executors variables file

### DIFF
--- a/inventory/group_vars/opentech-sl-zuul-executors
+++ b/inventory/group_vars/opentech-sl-zuul-executors
@@ -3,3 +3,7 @@ ansible_user: ubuntu
 
 zuul_components:
   - zuul-executor
+
+zuul_executor_variables:
+  bonnyci_logs_scp: "zuul@logs.opentech.bonnyci.org"
+  bonnyci_logs_dir: /var/www/bonny-logs/logs

--- a/roles/zuul-executor/defaults/main.yml
+++ b/roles/zuul-executor/defaults/main.yml
@@ -5,6 +5,7 @@ zuul_executor_finger_port: 79
 zuul_executor_git_dir: "{{ zuul_home_dir }}/executor-git"
 zuul_executor_private_key_file: "~/.ssh/id_rsa"
 zuul_executor_state_dir: "{{ zuul_home_dir }}/executor-state"
+zuul_executor_variables: {}
 zuul_executor_untrusted_wrapper: bubblewrap
 
 zuul_git_user_name: user@domain.io

--- a/roles/zuul-executor/tasks/main.yml
+++ b/roles/zuul-executor/tasks/main.yml
@@ -38,6 +38,12 @@
     group: zuul
   when: zuul_ssh_known_hosts is defined
 
+- name: Add site variables file
+  template:
+    src: etc/zuul/variables.yml
+    dest: "{{ zuul_executor_variables_file }}"
+    mode: 0644
+
 - name: Add bubblewrap PPA
   apt_repository:
     repo: "ppa:openstack-ci-core/bubblewrap"

--- a/roles/zuul-executor/templates/etc/zuul/variables.yml
+++ b/roles/zuul-executor/templates/etc/zuul/variables.yml
@@ -1,0 +1,2 @@
+---
+{{ zuul_executor_variables | to_nice_yaml }}

--- a/roles/zuul-executor/templates/etc/zuul/zuul.conf
+++ b/roles/zuul-executor/templates/etc/zuul/zuul.conf
@@ -22,6 +22,7 @@ git_dir = {{ zuul_executor_git_dir }}
 log_config = {{ zuul_config_dir }}/zuul-executor-logging.conf
 private_key_file = {{ zuul_executor_private_key_file }}
 state_dir = {{ zuul_executor_state_dir }}
+variables = {{ zuul_executor_variables_file }}
 untrusted_wrapper = {{ zuul_executor_untrusted_wrapper }}
 
 [merger]

--- a/roles/zuul-executor/vars/main.yml
+++ b/roles/zuul-executor/vars/main.yml
@@ -1,0 +1,2 @@
+---
+zuul_executor_variables_file: /etc/zuul/variables.yml


### PR DESCRIPTION
We can add site specific variables to our deployment via a variables
file. We should always install this.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>