### PR TITLE
Name executors correctly

### DIFF
--- a/inventory/opentech-sl
+++ b/inventory/opentech-sl
@@ -36,5 +36,5 @@ zuul.opentech.bonnyci.org
 [zuul-executor]
 ze01.internal.opentech.bonnyci.org
 
-[opentech-sl-zuul-exectuors:children]
+[opentech-sl-zuul-executors:children]
 zuul-executor


### PR DESCRIPTION
Ansible isn't picking up the executors variables correctly because
there's a spelling mistake in the group name.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>