### PR TITLE
Add --keep-jobdir option to zuul-executor

### DIFF
--- a/inventory/group_vars/opentech-sl-zuul-executors
+++ b/inventory/group_vars/opentech-sl-zuul-executors
@@ -4,6 +4,8 @@ ansible_user: ubuntu
 zuul_components:
   - zuul-executor
 
+zuul_executor_keep_jobdir: yes
+
 zuul_executor_variables:
   bonnyci_logs_scp: "zuul@logs.opentech.bonnyci.org"
   bonnyci_logs_dir: /var/www/bonny-logs/logs

--- a/roles/zuul-base/defaults/main.yml
+++ b/roles/zuul-base/defaults/main.yml
@@ -11,6 +11,7 @@ zuul_git_branch: github-integration
 
 zuul_service_enabled: yes
 zuul_service_start: yes
+zuul_service_params: ""
 
 zuul_statsd_enable: no
 zuul_statsd_host: 127.0.0.1

--- a/roles/zuul-base/templates/etc/systemd/system/zuul.service
+++ b/roles/zuul-base/templates/etc/systemd/system/zuul.service
@@ -8,7 +8,7 @@ User=zuul
 Group=zuul
 LimitNOFILE=8192
 EnvironmentFile=-/etc/default/{{ zuul_service_name }}
-ExecStart={{ zuul_venv_path }}/bin/{{ zuul_service_name }} -c {{ zuul_config_dir }}/{{ zuul_service_name }}.conf -d
+ExecStart={{ zuul_venv_path }}/bin/{{ zuul_service_name }} {{ zuul_service_params }} -c {{ zuul_config_dir }}/{{ zuul_service_name }}.conf -d
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]

--- a/roles/zuul-executor/defaults/main.yml
+++ b/roles/zuul-executor/defaults/main.yml
@@ -3,6 +3,7 @@ zuul_executor_default_username: "zuul"
 zuul_executor_disk_limit_per_job: 250
 zuul_executor_finger_port: 79
 zuul_executor_git_dir: "{{ zuul_home_dir }}/executor-git"
+zuul_executor_keep_jobdir: no
 zuul_executor_private_key_file: "~/.ssh/id_rsa"
 zuul_executor_state_dir: "{{ zuul_home_dir }}/executor-state"
 zuul_executor_variables: {}

--- a/roles/zuul-executor/meta/main.yml
+++ b/roles/zuul-executor/meta/main.yml
@@ -3,3 +3,4 @@ dependencies:
   - role: zuul-base
     zuul_service_name: zuul-executor
     zuul_service_start: no
+    zuul_service_params: "{% if zuul_executor_keep_jobdir | bool %}--keep-jobdir{% endif %}"


### PR DESCRIPTION
For debugging whilst the log upload is broken we really need a way to
keep the jobs around.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>