### PR TITLE
Connect to openstack gerrit

### DIFF
--- a/inventory/group_vars/opentech-sl
+++ b/inventory/group_vars/opentech-sl
@@ -93,6 +93,19 @@ zuul_connections:
     app_key: "{{ zuul_github_app_key_content | default(False) | ternary(zuul_github_app_key_file, '') }}"
     webhook_token: "{{ secrets.zuul_github_v3_webhook_token | default('') }}"
 
+  openstack:
+    driver: gerrit
+    user: BonnyCI
+    server: review.openstack.org
+    sshkey: /var/lib/zuul/secrets/openstack
+
+zuul_ssh_known_hosts:
+  - name: review.openstack.org
+    key: "[review.openstack.org]:29418 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfsIj/jqpI+2CFdjCL6kOiqdORWvxQ2sQbCzSzzmLXic8yVhCCbwarkvEpfUOHG4eyB0vqVZfMffxf0Yy3qjURrsroBCiuJ8GdiAcGdfYwHNfBI0cR6kydBZL537YDasIk0Z3ILzhwf7474LmkVzS7V2tMTb4ZiBS/jUeiHsVp88FZhIBkyhlb/awAGcUxT5U4QBXCAmerYXeB47FPuz9JFOVyF08LzH9JRe9tfXtqaCNhlSdRe/2pPRvn2EIhn5uHWwATACG9MBdrK8xv8LqPOik2w1JkgLWyBj11vDd5I3IjrmREGw8dqImqp0r6MD8rxqADlc1elfDIXYsy+TVH"
+
+zuul_scheduler_secrets:
+  openstack: "{{ secrets.ssh_keys.openstack.private }}"
+
 zuul_github_app_key_content: "{{ secrets.zuul_github_v3_app_key_content }}"
 
 zuul_tenants:

--- a/roles/zuul-base/defaults/main.yml
+++ b/roles/zuul-base/defaults/main.yml
@@ -13,6 +13,8 @@ zuul_service_enabled: yes
 zuul_service_start: yes
 zuul_service_params: ""
 
+zuul_ssh_known_hosts: []
+
 zuul_statsd_enable: no
 zuul_statsd_host: 127.0.0.1
 zuul_statsd_port: 8125

--- a/roles/zuul-base/tasks/main.yml
+++ b/roles/zuul-base/tasks/main.yml
@@ -57,3 +57,10 @@
     name: "{{ zuul_service_name }}"
     state: started
   when: zuul_service_start
+
+- name: Install any ssh known host keys
+  known_hosts:
+    path: "/etc/ssh/ssh_known_hosts"
+    key: "{{ item.key }}"
+    host: "{{ item.host }}"
+  with_items: "{{ zuul_ssh_known_hosts }}"

--- a/roles/zuul-scheduler/defaults/main.yml
+++ b/roles/zuul-scheduler/defaults/main.yml
@@ -6,6 +6,9 @@ zuul_logs_url: http://{{ ansible_fqdn }}
 
 zuul_scheduler_state_dir: "{{ zuul_home_dir }}/scheduler-state"
 
+zuul_scheduler_secrets: {}
+zuul_scheduler_secrets_dir: "{{ zuul_home_dir }}/secrets"
+
 zuul_tenants: []
 zuul_tenant_src_file: "{{ zuul_config_dir }}/tenant.yml"
 zuul_tenant_dest_file: "{{ zuul_tenant_dest_file }}"

--- a/roles/zuul-scheduler/tasks/main.yml
+++ b/roles/zuul-scheduler/tasks/main.yml
@@ -6,6 +6,14 @@
     owner: zuul
     group: zuul
 
+- name: Create zuul secrets dir
+  file:
+    path: "{{ zuul_scheduler_secrets_dir }}"
+    state: directory
+    owner: zuul
+    group: zuul
+    mode: "0700"
+
 - name: Install gearman logging configs
   template:
     src: "etc/zuul/gearman-logging.conf"
@@ -20,6 +28,15 @@
     group: zuul
     mode: 0400
   when: zuul_github_app_key_content | default(False)
+
+- name: Install connection secrets
+  copy:
+    dest: "{{ zuul_scheduler_secrets_dir }}/{{ item.key }}"
+    content: "{{ item.value }}"
+    mode: "0600"
+    owner: zuul
+    group: zuul
+  with_dict: "{{ zuul_scheduler_secrets }}"
 
 # FIXME: need to figure out some way of notify/running integration-handler here
 - name: Install tenant.yaml


### PR DESCRIPTION
Add a zuul connection into openstack's gerrit. We may or may not want to
actually test things from here, but it's going to be required to consume
things like zuul-jobs from there.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>