### PR TITLE
Add openstack-infra/zuul-jobs as a config repo

### DIFF
--- a/inventory/group_vars/opentech-sl
+++ b/inventory/group_vars/opentech-sl
@@ -115,6 +115,10 @@ zuul_tenants:
         config-projects:
           - BonnyCI/project-config
 
+      openstack:
+        config-projects:
+          - openstack-infra/project-config
+
       gerrithub:
         untrusted-projects:
           - BonnyCI/sandbox-v3


### PR DESCRIPTION
As much as possible we should reuse upstream zuul jobs so import them
into our configuration.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>