### PR TITLE
Move zuul secrets to zuul-base

### DIFF
--- a/inventory/group_vars/opentech-sl
+++ b/inventory/group_vars/opentech-sl
@@ -99,12 +99,13 @@ zuul_connections:
     server: review.openstack.org
     sshkey: /var/lib/zuul/secrets/openstack
 
+zuul_secrets:
+  - name: openstack
+    content: "{{ secrets.ssh_keys.openstack.private }}"
+
 zuul_ssh_known_hosts:
   - name: review.openstack.org
     key: "[review.openstack.org]:29418 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfsIj/jqpI+2CFdjCL6kOiqdORWvxQ2sQbCzSzzmLXic8yVhCCbwarkvEpfUOHG4eyB0vqVZfMffxf0Yy3qjURrsroBCiuJ8GdiAcGdfYwHNfBI0cR6kydBZL537YDasIk0Z3ILzhwf7474LmkVzS7V2tMTb4ZiBS/jUeiHsVp88FZhIBkyhlb/awAGcUxT5U4QBXCAmerYXeB47FPuz9JFOVyF08LzH9JRe9tfXtqaCNhlSdRe/2pPRvn2EIhn5uHWwATACG9MBdrK8xv8LqPOik2w1JkgLWyBj11vDd5I3IjrmREGw8dqImqp0r6MD8rxqADlc1elfDIXYsy+TVH"
-
-zuul_scheduler_secrets:
-  openstack: "{{ secrets.ssh_keys.openstack.private }}"
 
 zuul_github_app_key_content: "{{ secrets.zuul_github_v3_app_key_content }}"
 

--- a/roles/zuul-base/defaults/main.yml
+++ b/roles/zuul-base/defaults/main.yml
@@ -9,6 +9,9 @@ zuul_gearman_port: 4730
 zuul_git_repo_url: https://github.com/BonnyCI/zuul
 zuul_git_branch: github-integration
 
+zuul_secrets: []
+zuul_secrets_dir: "{{ zuul_home_dir }}/secrets"
+
 zuul_service_enabled: yes
 zuul_service_start: yes
 zuul_service_params: ""

--- a/roles/zuul-base/tasks/main.yml
+++ b/roles/zuul-base/tasks/main.yml
@@ -14,20 +14,32 @@
 
 - name: Create directories
   file:
-    path: "{{ item }}"
+    path: "{{ item.name }}"
     state: directory
-    mode: 0755
+    mode: "{{ item.mode | default('0755') }}"
     owner: zuul
     group: zuul
   with_items:
-    - "{{ zuul_config_dir }}"
-    - "{{ zuul_log_dir }}"
+    - name: "{{ zuul_config_dir }}"
+    - name: "{{ zuul_log_dir }}"
+    - name: "{{ zuul_secrets_dir }}"
+      mode: "0700"
 
 - name: Install zuul config
   template:
     src:  "{{ zuul_template_config }}"
     dest: "{{ zuul_config_dir }}/{{ zuul_service_name }}.conf"
     owner: zuul
+
+- name: Install connection secrets
+  copy:
+    dest: "{{ zuul_secrets_dir }}/{{ item.name }}"
+    src: "{{ item.src | default(omit) }}"
+    content: "{{ item.content | default(omit) }}"
+    mode: "{{ item.mode | default('0600') }}"
+    owner: zuul
+    group: zuul
+  with_items: "{{ zuul_secrets }}"
 
 - name: Install service environment configs
   template:

--- a/roles/zuul-scheduler/defaults/main.yml
+++ b/roles/zuul-scheduler/defaults/main.yml
@@ -6,9 +6,6 @@ zuul_logs_url: http://{{ ansible_fqdn }}
 
 zuul_scheduler_state_dir: "{{ zuul_home_dir }}/scheduler-state"
 
-zuul_scheduler_secrets: {}
-zuul_scheduler_secrets_dir: "{{ zuul_home_dir }}/secrets"
-
 zuul_tenants: []
 zuul_tenant_src_file: "{{ zuul_config_dir }}/tenant.yml"
 zuul_tenant_dest_file: "{{ zuul_tenant_dest_file }}"

--- a/roles/zuul-scheduler/tasks/main.yml
+++ b/roles/zuul-scheduler/tasks/main.yml
@@ -6,14 +6,6 @@
     owner: zuul
     group: zuul
 
-- name: Create zuul secrets dir
-  file:
-    path: "{{ zuul_scheduler_secrets_dir }}"
-    state: directory
-    owner: zuul
-    group: zuul
-    mode: "0700"
-
 - name: Install gearman logging configs
   template:
     src: "etc/zuul/gearman-logging.conf"
@@ -28,15 +20,6 @@
     group: zuul
     mode: 0400
   when: zuul_github_app_key_content | default(False)
-
-- name: Install connection secrets
-  copy:
-    dest: "{{ zuul_scheduler_secrets_dir }}/{{ item.key }}"
-    content: "{{ item.value }}"
-    mode: "0600"
-    owner: zuul
-    group: zuul
-  with_dict: "{{ zuul_scheduler_secrets }}"
 
 # FIXME: need to figure out some way of notify/running integration-handler here
 - name: Install tenant.yaml


### PR DESCRIPTION
So it makes sense that we need the ssh key for things like gerrit to be
present on the merger and executor so we can actually do a priviledged
clone.

Put the secrets in zuul-base. Each zuul- role already has all the
connection information anyway.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>