### PR TITLE
Use openstack-infra/zuul-jobs not project-config

### DIFF
--- a/inventory/group_vars/opentech-sl
+++ b/inventory/group_vars/opentech-sl
@@ -113,8 +113,8 @@ zuul_tenants:
           - BonnyCI/project-config
 
       openstack:
-        config-projects:
-          - openstack-infra/project-config
+        untrusted-projects:
+          - openstack-infra/zuul-jobs
 
       gerrithub:
         untrusted-projects:


### PR DESCRIPTION
Mistake, we don't actually want to depend on openstack's project-config
at all, we want to just inherit the job repos.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>