### PR TITLE
The log server has to use apache

### DIFF
--- a/inventory/group_vars/log
+++ b/inventory/group_vars/log
@@ -6,6 +6,8 @@ bonnyci_logs_apache_mods_install:
   - proxy.load
   - proxy_uwsgi.load
 
+bonnyci_use_apache: yes
+
 bonnyci_logs_apache_vhosts:
   - name: logs
     server_name: "{{ bonnyci_logs_server_name | default('logs') }}"


### PR DESCRIPTION
There's no nginx transition written for the crazy loganalyze stuff that
the log server does. Make it so that the log server always uses apache.

This may not work if opentech-sl takes priority, just going to do it and
see if it needs to be a host_var or something.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>