### PR TITLE
Set use_apache on the logs host_var

### DIFF
--- a/inventory/host_vars/logs.opentech.bonnyci.org
+++ b/inventory/host_vars/logs.opentech.bonnyci.org
@@ -2,5 +2,6 @@
 ansible_host: logs.internal.opentech.bonnyci.org
 ansible_user: ubuntu
 
+bonnyci_use_apache: yes
 bonnyci_logs_ssl: yes
 letsencrypt_csr_cn: logs.opentech.bonnyci.org


### PR DESCRIPTION
The group_var didn't appear to work, instead set use_apache on the log
host_var which should definitely take priority.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>