### PR TITLE
Add bonnyci-requirements

### DIFF
--- a/inventory/group_vars/opentech-sl
+++ b/inventory/group_vars/opentech-sl
@@ -63,6 +63,7 @@ nodepool_diskimages:
       - pip-and-virtualenv
       - nodepool
       - bonnyci-nodepool
+      - bonnyci-requirements
     release: xenial
     env-vars:
       DIB_DEV_USER_USERNAME: zuul

--- a/roles/nodepool/files/etc/nodepool/elements/bonnyci-requirements/README.rst
+++ b/roles/nodepool/files/etc/nodepool/elements/bonnyci-requirements/README.rst
@@ -1,0 +1,2 @@
+Install packages that will be commonly required on nodes
+

--- a/roles/nodepool/files/etc/nodepool/elements/bonnyci-requirements/element-deps
+++ b/roles/nodepool/files/etc/nodepool/elements/bonnyci-requirements/element-deps
@@ -1,0 +1,1 @@
+package-installs

--- a/roles/nodepool/files/etc/nodepool/elements/bonnyci-requirements/environment.d/50-bonnyci
+++ b/roles/nodepool/files/etc/nodepool/elements/bonnyci-requirements/environment.d/50-bonnyci
@@ -1,0 +1,1 @@
+export BONNYCI_VENV_PATH=${BONNYCI_VENV_PATH:-/opt/venvs}

--- a/roles/nodepool/files/etc/nodepool/elements/bonnyci-requirements/install.d/50-python
+++ b/roles/nodepool/files/etc/nodepool/elements/bonnyci-requirements/install.d/50-python
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+
+# dib-lint: disable=setu setpipefail
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -e
+
+sudo mkdir -p $BONNYCI_VENV_PATH
+
+sudo -H virtualenv -p `which python3` $BONNYCI_VENV_PATH/bindep
+sudo -H $BONNYCI_VENV_PATH/bindep/bin/pip install bindep

--- a/roles/nodepool/files/etc/nodepool/elements/bonnyci-requirements/package-installs.yaml
+++ b/roles/nodepool/files/etc/nodepool/elements/bonnyci-requirements/package-installs.yaml
@@ -1,0 +1,2 @@
+python-dev:
+python3-dev:

--- a/roles/nodepool/files/etc/nodepool/elements/bonnyci-requirements/pkg-map
+++ b/roles/nodepool/files/etc/nodepool/elements/bonnyci-requirements/pkg-map
@@ -1,0 +1,20 @@
+{
+  "family": {
+    "gentoo": {
+      "python-dev": "dev-lang/python",
+      "python3-dev": "dev-lang/python"
+    },
+    "suse": {
+      "python-dev": "python-devel",
+      "python3-dev": "python3-devel",
+    },
+    "redhat": {
+      "python-dev": "python2-devel",
+      "python3-dev": "python3-devel"
+    }
+  },
+  "default": {
+    "python-dev": "",
+    "python3-dev": ""
+  }
+}


### PR DESCRIPTION
Add a base bonny role that will setup standard installed packages onto
bonnyci worker nodes.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>