### PR TITLE
Install an ansible fact for bindep_command

### DIFF
--- a/roles/nodepool/files/etc/nodepool/elements/bonnyci-requirements/install.d/10-ansible-facts
+++ b/roles/nodepool/files/etc/nodepool/elements/bonnyci-requirements/install.d/10-ansible-facts
@@ -17,13 +17,4 @@ if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
 fi
 set -e
 
-sudo mkdir -p $BONNYCI_VENV_PATH
-
-sudo -H virtualenv -p `which python3` $BONNYCI_VENV_PATH/bindep
-sudo -H $BONNYCI_VENV_PATH/bindep/bin/pip install bindep
-
-sudo cat << EOF >/etc/ansible/facts.d/bonnyci-python.fact
-{
-    "bindep_command": "$BONNYCI_VENV_PATH/bindep/bin/bindep"
-}
-EOF
+sudo mkdir -p /etc/ansible/facts.d


### PR DESCRIPTION
We're installing bindep into our base images but to have the zuul
ansible pick it up in a non-standard virtualenv location we need to set
the bindep_command variable. We can set this from our zuul environment
however it really makes more sense to set the fact from the same place
as the command is installed.

This is not really tested. Do it live!

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>