### PR TITLE
Escape double brackets in site variables

### DIFF
--- a/inventory/group_vars/opentech-sl-zuul-executors
+++ b/inventory/group_vars/opentech-sl-zuul-executors
@@ -7,6 +7,6 @@ zuul_components:
 zuul_executor_keep_jobdir: yes
 
 zuul_executor_variables:
-  bindep_command: "{{ ansible_local.bonnyci_image.bindep_command | default('') }}"
+  bindep_command: "{{ '{{' }} ansible_local.bonnyci_image.bindep_command | default('') {{ '}}' }}"
   bonnyci_logs_scp: "zuul@logs.opentech.bonnyci.org"
   bonnyci_logs_dir: /var/www/bonny-logs/logs


### PR DESCRIPTION
If we put the {{ syntax directly into ansible then ansible will try to
interpret it. We need to escape them so that it ends up being put into
the site variables file.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>