### PR TITLE
Install apt-transport-https on all images

### DIFF
--- a/roles/nodepool/files/etc/nodepool/elements/bonnyci-nodepool/package-installs.yaml
+++ b/roles/nodepool/files/etc/nodepool/elements/bonnyci-nodepool/package-installs.yaml
@@ -1,3 +1,4 @@
+apt-transport-https:
 ubuntu-minimal:
 build-essential:
 python-dev:


### PR DESCRIPTION
We almost always want apt-transport-https available so it's much better
to install it in the image.

This will only work on ubuntu - but so will most of the things in this
element.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>